### PR TITLE
dkpro-jwpl-hibernate-5.2.1-spring-4.3.0-migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
+### Rules for Maven build
+target
+.class
+
+### Rules for Eclipse environments
 .settings
 .classpath
 .project
-target
-.class
+
+### Rules for IntelliJ IDEA environments
+.idea
+*.iml

--- a/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/api/Category.java
+++ b/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/api/Category.java
@@ -17,17 +17,18 @@
  *******************************************************************************/
 package de.tudarmstadt.ukp.wikipedia.api;
 
-import java.math.BigInteger;
-import java.util.HashSet;
-import java.util.Set;
-
-import org.hibernate.LockMode;
-import org.hibernate.Session;
-
 import de.tudarmstadt.ukp.wikipedia.api.exception.WikiApiException;
 import de.tudarmstadt.ukp.wikipedia.api.exception.WikiPageNotFoundException;
 import de.tudarmstadt.ukp.wikipedia.api.exception.WikiTitleParsingException;
 import de.tudarmstadt.ukp.wikipedia.api.hibernate.CategoryDAO;
+import org.hibernate.LockMode;
+import org.hibernate.Session;
+import org.hibernate.type.LongType;
+import org.hibernate.type.StringType;
+
+import java.math.BigInteger;
+import java.util.HashSet;
+import java.util.Set;
 
 public class Category implements WikiConstants {
 
@@ -46,7 +47,7 @@ public class Category implements WikiConstants {
         this.wiki = wiki;
         catDAO = new CategoryDAO(wiki);
         createCategory(id);
-    };
+    }
 
     /**
      * Creates a category object.
@@ -58,7 +59,7 @@ public class Category implements WikiConstants {
         this.wiki = wiki;
         catDAO = new CategoryDAO(wiki);
         createCategory(pageID);
-    };
+    }
 
     /**
      * Creates a category object.
@@ -106,9 +107,9 @@ public class Category implements WikiConstants {
         session.beginTransaction();
 
         Object returnValue;
-        returnValue = session.createSQLQuery(
+        returnValue = session.createNativeQuery(
                 "select cat.pageId from Category as cat where cat.name = :name COLLATE utf8_bin")
-                .setString("name", name)
+                .setParameter("name", name, StringType.INSTANCE)
                 .uniqueResult();
         session.getTransaction().commit();
 
@@ -178,8 +179,8 @@ public class Category implements WikiConstants {
         long id = this.__getId();
         Session session = this.wiki.__getHibernateSession();
         session.beginTransaction();
-        Object returnValue = session.createSQLQuery("select count(inLinks) from category_inlinks where id = :id")
-            .setLong("id", id)
+        Object returnValue = session.createNativeQuery("select count(inLinks) from category_inlinks where id = :id")
+            .setParameter("id", id, LongType.INSTANCE)
             .uniqueResult();
         session.getTransaction().commit();
 
@@ -229,8 +230,8 @@ public class Category implements WikiConstants {
         long id = this.__getId();
         Session session = this.wiki.__getHibernateSession();
         session.beginTransaction();
-        Object returnValue = session.createSQLQuery("select count(outLinks) from category_outlinks where id = :id")
-            .setLong("id", id)
+        Object returnValue = session.createNativeQuery("select count(outLinks) from category_outlinks where id = :id")
+            .setParameter("id", id, LongType.INSTANCE)
             .uniqueResult();
         session.getTransaction().commit();
 
@@ -333,8 +334,8 @@ public class Category implements WikiConstants {
         long id = this.__getId();
         Session session = this.wiki.__getHibernateSession();
         session.beginTransaction();
-        Object returnValue = session.createSQLQuery("select count(pages) from category_pages where id = :id")
-            .setLong("id", id)
+        Object returnValue = session.createNativeQuery("select count(pages) from category_pages where id = :id")
+            .setParameter("id", id, LongType.INSTANCE)
             .uniqueResult();
         session.getTransaction().commit();
 

--- a/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/api/Page.java
+++ b/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/api/Page.java
@@ -17,18 +17,6 @@
  *******************************************************************************/
 package de.tudarmstadt.ukp.wikipedia.api;
 
-import java.math.BigInteger;
-import java.util.HashSet;
-import java.util.Set;
-
-import org.hibernate.LockOptions;
-import org.hibernate.Session;
-import org.sweble.wikitext.engine.CompiledPage;
-import org.sweble.wikitext.engine.Compiler;
-import org.sweble.wikitext.engine.PageId;
-import org.sweble.wikitext.engine.PageTitle;
-import org.sweble.wikitext.engine.utils.SimpleWikiConfiguration;
-
 import de.fau.cs.osr.ptk.common.AstVisitor;
 import de.tudarmstadt.ukp.wikipedia.api.exception.WikiApiException;
 import de.tudarmstadt.ukp.wikipedia.api.exception.WikiPageNotFoundException;
@@ -36,6 +24,20 @@ import de.tudarmstadt.ukp.wikipedia.api.exception.WikiTitleParsingException;
 import de.tudarmstadt.ukp.wikipedia.api.hibernate.PageDAO;
 import de.tudarmstadt.ukp.wikipedia.api.sweble.PlainTextConverter;
 import de.tudarmstadt.ukp.wikipedia.util.UnmodifiableArraySet;
+import org.hibernate.LockOptions;
+import org.hibernate.Session;
+import org.hibernate.type.IntegerType;
+import org.hibernate.type.LongType;
+import org.hibernate.type.StringType;
+import org.sweble.wikitext.engine.CompiledPage;
+import org.sweble.wikitext.engine.Compiler;
+import org.sweble.wikitext.engine.PageId;
+import org.sweble.wikitext.engine.PageTitle;
+import org.sweble.wikitext.engine.utils.SimpleWikiConfiguration;
+
+import java.math.BigInteger;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Represents a Wikipedia article page.
@@ -174,7 +176,7 @@ public class Page
         Session session = this.wiki.__getHibernateSession();
         session.beginTransaction();
 		hibernatePage = (de.tudarmstadt.ukp.wikipedia.api.hibernate.Page) session
-				.createQuery("from Page where pageId = :id").setInteger("id", pageID).uniqueResult();
+				.createQuery("from Page where pageId = :id").setParameter("id", pageID, IntegerType.INSTANCE).uniqueResult();
         session.getTransaction().commit();
 
         if (hibernatePage == null) {
@@ -200,9 +202,9 @@ public class Page
 		session = this.wiki.__getHibernateSession();
 		session.beginTransaction();
 		Integer pageId = (Integer) session
-				.createSQLQuery(
+				.createNativeQuery(
 						"select pml.pageID from PageMapLine as pml where pml.name = :pagetitle LIMIT 1")
-				.setString("pagetitle", searchString).uniqueResult();
+				.setParameter("pagetitle", searchString, StringType.INSTANCE).uniqueResult();
 		session.getTransaction().commit();
 
         if (pageId == null) {
@@ -292,8 +294,8 @@ public class Page
 		Session session = wiki.__getHibernateSession();
 		 session.beginTransaction();
 		Object returnValue = session
-				.createSQLQuery("select count(pages) from page_categories where id = :pageid")
-				.setLong("pageid", id).uniqueResult();
+				.createNativeQuery("select count(pages) from page_categories where id = :pageid")
+				.setParameter("pageid", id, LongType.INSTANCE).uniqueResult();
 		 session.getTransaction().commit();
 
 		if (returnValue != null) {
@@ -347,8 +349,8 @@ public class Page
 		Session session = wiki.__getHibernateSession();
 		session.beginTransaction();
 		Object returnValue = session
-				.createSQLQuery("select count(pi.inLinks) from page_inlinks as pi where pi.id = :piid")
-				.setLong("piid", id).uniqueResult();
+				.createNativeQuery("select count(pi.inLinks) from page_inlinks as pi where pi.id = :piid")
+				.setParameter("piid", id, LongType.INSTANCE).uniqueResult();
 		session.getTransaction().commit();
 
 		if (returnValue != null) {
@@ -423,8 +425,8 @@ public class Page
 		Session session = wiki.__getHibernateSession();
 		session.beginTransaction();
 		Object returnValue = session
-				.createSQLQuery("select count(outLinks) from page_outlinks where id = :id")
-				.setLong("id", id).uniqueResult();
+				.createNativeQuery("select count(outLinks) from page_outlinks where id = :id")
+				.setParameter("id", id, LongType.INSTANCE).uniqueResult();
 		session.getTransaction().commit();
 
 		if (returnValue != null) {

--- a/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/api/TitleIterator.java
+++ b/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/api/TitleIterator.java
@@ -17,13 +17,12 @@
  *******************************************************************************/
 package de.tudarmstadt.ukp.wikipedia.api;
 
+import de.tudarmstadt.ukp.wikipedia.api.exception.WikiTitleParsingException;
+import org.hibernate.Session;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-
-import org.hibernate.Session;
-
-import de.tudarmstadt.ukp.wikipedia.api.exception.WikiTitleParsingException;
 
 /**
  * An iterator over category objects.
@@ -125,7 +124,7 @@ public class TitleIterator implements Iterator<Title> {
 
             Session session = this.wiki.__getHibernateSession();
             session.beginTransaction();
-            List returnList = session.createSQLQuery(
+            List returnList = session.createNativeQuery(
             "select p.name from PageMapLine as p")
                 .setFirstResult(dataOffset)
                 .setMaxResults(maxBufferSize)

--- a/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/api/hibernate/WikiHibernateUtil.java
+++ b/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/api/hibernate/WikiHibernateUtil.java
@@ -17,16 +17,15 @@
  *******************************************************************************/
 package de.tudarmstadt.ukp.wikipedia.api.hibernate;
 
+import de.tudarmstadt.ukp.wikipedia.api.DatabaseConfiguration;
+import de.tudarmstadt.ukp.wikipedia.api.WikiConstants;
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.Configuration;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-
-import org.hibernate.SessionFactory;
-import org.hibernate.cfg.Configuration;
-import org.hibernate.service.ServiceRegistryBuilder;
-
-import de.tudarmstadt.ukp.wikipedia.api.DatabaseConfiguration;
-import de.tudarmstadt.ukp.wikipedia.api.WikiConstants;
 
 public class WikiHibernateUtil implements WikiConstants {
 
@@ -47,8 +46,8 @@ public class WikiHibernateUtil implements WikiConstants {
         String uniqueSessionKey = config.getLanguage().toString() + config.getHost() + config.getDatabase();
         if (!sessionFactoryMap.containsKey(uniqueSessionKey)) {
         	Configuration configuration = getConfiguration(config);
-            ServiceRegistryBuilder ssrb = new ServiceRegistryBuilder().applySettings(configuration.getProperties());            
-            SessionFactory sessionFactory = configuration.buildSessionFactory(ssrb.buildServiceRegistry());
+            StandardServiceRegistryBuilder ssrb = new StandardServiceRegistryBuilder().applySettings(configuration.getProperties());
+            SessionFactory sessionFactory = configuration.buildSessionFactory(ssrb.build());
             sessionFactoryMap.put(uniqueSessionKey, sessionFactory);
         }
         return sessionFactoryMap.get(uniqueSessionKey);

--- a/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/api/hibernate/WikiHibernateUtil.java
+++ b/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/api/hibernate/WikiHibernateUtil.java
@@ -82,8 +82,12 @@ public class WikiHibernateUtil implements WikiConstants {
         p.setProperty("hibernate.show_sql","false");
 
         // Update schema
-        p.setProperty("hibernate.hbm2ddl.auto","update");
-        
+        p.setProperty("hibernate.hbm2ddl.auto","validate");
+
+        // Avoid long running connection acquisition:
+        // Important performance fix to obtain jdbc connections a lot faster by avoiding metadata fetching
+        p.setProperty("hibernate.temp.use_jdbc_metadata_defaults","false");
+
         return p;
     }
 

--- a/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/api/hibernate/WikiHibernateUtil.java
+++ b/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/api/hibernate/WikiHibernateUtil.java
@@ -88,6 +88,15 @@ public class WikiHibernateUtil implements WikiConstants {
         // Important performance fix to obtain jdbc connections a lot faster by avoiding metadata fetching
         p.setProperty("hibernate.temp.use_jdbc_metadata_defaults","false");
 
+        // Set C3P0 Connection Pool in case somebody wants to use it in production settings
+        // if no C3P0 is available at runtime, related warnings can be ignored safely as the built-in CP will be used.
+        p.setProperty("hibernate.c3p0.acquire_increment","3");
+        p.setProperty("hibernate.c3p0.idle_test_period","300");
+        p.setProperty("hibernate.c3p0.min_size","3");
+        p.setProperty("hibernate.c3p0.max_size","15");
+        p.setProperty("hibernate.c3p0.max_statements","10");
+        p.setProperty("hibernate.c3p0.timeout","1000");
+
         return p;
     }
 

--- a/de.tudarmstadt.ukp.wikipedia.api/src/test/resources/log4j.properties
+++ b/de.tudarmstadt.ukp.wikipedia.api/src/test/resources/log4j.properties
@@ -1,6 +1,6 @@
 # Copyright 2016
 # Ubiquitous Knowledge Processing (UKP) Lab
-# Technische Universit�t Darmstadt
+# Technische Universität Darmstadt
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/de.tudarmstadt.ukp.wikipedia.api/src/test/resources/log4j.properties
+++ b/de.tudarmstadt.ukp.wikipedia.api/src/test/resources/log4j.properties
@@ -1,6 +1,6 @@
 # Copyright 2016
 # Ubiquitous Knowledge Processing (UKP) Lab
-# Technische Universität Darmstadt
+# Technische Universitï¿½t Darmstadt
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -59,6 +59,9 @@ log4j.logger.org.hibernate.tool.hbm2ddl=debug
 
 ### log JDBC resource acquisition
 #log4j.logger.org.hibernate.jdbc=debug
+
+### log only errors of internal JDBC connection provider
+log4j.logger.org.hibernate.engine.jdbc.connections.internal=error
 
 ### enable the following line if you want to track down connection ###
 ### leakages when using DriverManagerConnectionProvider ###

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,18 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.target>1.7</maven.compiler.target>
 		<maven.compiler.source>1.7</maven.compiler.source>
+
+		<ukp.wikipedia.version>1.2.0-SNAPSHOT</ukp.wikipedia.version>
+
+		<fau.ptk.version>1.1.1</fau.ptk.version>
+		<fau.utils.version>0.3.1</fau.utils.version>
+
+		<hibernate.version>5.2.1.Final</hibernate.version>
+		<spring.version>4.3.0.RELEASE</spring.version>
+		<mysql.version>5.1.39</mysql.version>
+		<postgresql.version>9.4.1208</postgresql.version>
+
+
 	</properties>
 	<scm>
 		<connection>scm:git:https://github.com/dkpro/dkpro-jwpl</connection>
@@ -68,12 +80,13 @@
 			<email>richard.eckart@googlemail.com</email>
 		</developer>
 	</developers>
+
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
-				<version>4.10</version>
+				<version>4.11</version>
 			</dependency>
 			<dependency>
 				<groupId>log4j</groupId>
@@ -97,12 +110,12 @@
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-core</artifactId>
-				<version>4.1.3.Final</version>
+				<version>${hibernate.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-c3p0</artifactId>
-				<version>4.1.3.Final</version>
+				<version>${hibernate.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.jgrapht</groupId>
@@ -117,7 +130,12 @@
 			<dependency>
 				<groupId>mysql</groupId>
 				<artifactId>mysql-connector-java</artifactId>
-				<version>5.1.21</version>
+				<version>${mysql.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.postgresql</groupId>
+				<artifactId>postgresql</artifactId>
+				<version>${postgresql.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>jfree</groupId>
@@ -137,12 +155,12 @@
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-core</artifactId>
-				<version>3.1.1.RELEASE</version>
+				<version>${spring.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-beans</artifactId>
-				<version>3.1.1.RELEASE</version>
+				<version>${spring.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.wikimedia</groupId>
@@ -160,11 +178,6 @@
 				<version>1.1.1</version>
 			</dependency>
 			<dependency>
-				<groupId>postgresql</groupId>
-				<artifactId>postgresql</artifactId>
-				<version>9.0-801.jdbc4</version>
-			</dependency>
-			<dependency>
 				<groupId>net.java.dev.swing-layout</groupId>
 				<artifactId>swing-layout</artifactId>
 				<version>1.0.2</version>
@@ -172,42 +185,47 @@
 			<dependency>
 				<groupId>de.tudarmstadt.ukp.wikipedia</groupId>
 				<artifactId>de.tudarmstadt.ukp.wikipedia.api</artifactId>
-				<version>1.2.0-SNAPSHOT</version>
+				<version>${ukp.wikipedia.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>de.tudarmstadt.ukp.wikipedia</groupId>
 				<artifactId>de.tudarmstadt.ukp.wikipedia.datamachine</artifactId>
-				<version>1.2.0-SNAPSHOT</version>
+				<version>${ukp.wikipedia.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>de.tudarmstadt.ukp.wikipedia</groupId>
 				<artifactId>de.tudarmstadt.ukp.wikipedia.mwdumper</artifactId>
-				<version>1.2.0-SNAPSHOT</version>
+				<version>${ukp.wikipedia.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>de.tudarmstadt.ukp.wikipedia</groupId>
 				<artifactId>de.tudarmstadt.ukp.wikipedia.timemachine</artifactId>
-				<version>1.2.0-SNAPSHOT</version>
+				<version>${ukp.wikipedia.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>de.tudarmstadt.ukp.wikipedia</groupId>
 				<artifactId>de.tudarmstadt.ukp.wikipedia.revisionmachine</artifactId>
-				<version>1.2.0-SNAPSHOT</version>
+				<version>${ukp.wikipedia.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>de.tudarmstadt.ukp.wikipedia</groupId>
 				<artifactId>de.tudarmstadt.ukp.wikipedia.util</artifactId>
-				<version>1.2.0-SNAPSHOT</version>
+				<version>${ukp.wikipedia.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>de.tudarmstadt.ukp.wikipedia</groupId>
 				<artifactId>de.tudarmstadt.ukp.wikipedia.wikimachine</artifactId>
-				<version>1.2.0-SNAPSHOT</version>
+				<version>${ukp.wikipedia.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>de.tudarmstadt.ukp.wikipedia</groupId>
+				<artifactId>de.tudarmstadt.ukp.wikipedia.parser</artifactId>
+				<version>${ukp.wikipedia.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.javassist</groupId>
 				<artifactId>javassist</artifactId>
-				<version>3.16.1-GA</version>
+				<version>3.20.0-GA</version>
 			</dependency>
 			<dependency>
 				<groupId>org.sweble.wikitext</groupId>
@@ -220,21 +238,14 @@
 				<version>1.1.0</version>
 			</dependency>
 			<dependency>
-				<groupId>de.fau.cs.osr.utils</groupId>
-				<artifactId>utils</artifactId>
-				<version>0.3.0</version>
-			</dependency>
-			<dependency>
 				<groupId>de.fau.cs.osr.ptk</groupId>
 				<artifactId>ptk-common</artifactId>
-				<version>1.1.0</version>
+				<version>${fau.ptk.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>de.tudarmstadt.ukp.wikipedia</groupId>
-				<artifactId>
-					de.tudarmstadt.ukp.wikipedia.parser
-				</artifactId>
-				<version>1.2.0-SNAPSHOT</version>
+				<groupId>de.fau.cs.osr.utils</groupId>
+				<artifactId>utils</artifactId>
+				<version>${fau.utils.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-lang</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 		<fau.utils.version>0.3.1</fau.utils.version>
 
 		<hibernate.version>5.2.1.Final</hibernate.version>
-		<spring.version>4.3.0.RELEASE</spring.version>
+		<spring.version>4.3.1.RELEASE</spring.version>
 		<mysql.version>5.1.39</mysql.version>
 		<postgresql.version>9.4.1208</postgresql.version>
 


### PR DESCRIPTION
provides changes that upgrade JWPL to use modern framework dependencies:
- Hibernate 5.2.1.Final (it was: 4.1.3.Final)
- Spring 4.3.1.RELEASE (it was: 3.1.1.RELEASE)
- applies necessary fixes that would break the code in WikiHibernateUtil
- removes deprecated warnings in several Hibernate bound classes related to Hibernate 4.x -> 5.x update
- updates some JDBC driver dependencies such as MySQL and PostgreSQL to more recent versions