### PR TITLE
Fixed SAXParseException

### DIFF
--- a/de.tudarmstadt.ukp.wikipedia.mwdumper/src/main/java/de/tudarmstadt/ukp/wikipedia/mwdumper/importer/XmlDumpReader.java
+++ b/de.tudarmstadt.ukp.wikipedia.mwdumper/src/main/java/de/tudarmstadt/ukp/wikipedia/mwdumper/importer/XmlDumpReader.java
@@ -83,6 +83,7 @@ public class XmlDumpReader  extends DefaultHandler {
 	public void readDump() throws IOException {
 		try {
 			SAXParserFactory factory = SAXParserFactory.newInstance();
+			factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, false);
 			SAXParser parser = factory.newSAXParser();
 	
 			parser.parse(input, this);

--- a/de.tudarmstadt.ukp.wikipedia.wikimachine/src/main/java/de/tudarmstadt/ukp/wikipedia/wikimachine/dump/xml/AbstractXmlDumpReader.java
+++ b/de.tudarmstadt.ukp.wikipedia.wikimachine/src/main/java/de/tudarmstadt/ukp/wikipedia/wikimachine/dump/xml/AbstractXmlDumpReader.java
@@ -200,6 +200,7 @@ public abstract class AbstractXmlDumpReader extends DefaultHandler {
 	public void readDump() throws IOException {
 		try {
 			SAXParserFactory factory = SAXParserFactory.newInstance();
+			factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, false);
 			SAXParser parser = factory.newSAXParser();
 
 			parser.parse(input, this);


### PR DESCRIPTION
Disabled secure processing because it was unnecessarily setting limits on the accumulated size of entities.
https://github.com/dkpro/dkpro-jwpl/issues/139
https://github.com/dkpro/dkpro-jwpl/issues/144

This contribution shall be under the terms and conditions of the Apache License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.