### PR TITLE
Reduce drastically computation time

### DIFF
--- a/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/api/CategoryGraph.java
+++ b/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/api/CategoryGraph.java
@@ -17,6 +17,8 @@
  *******************************************************************************/
 package de.tudarmstadt.ukp.wikipedia.api;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -1643,8 +1645,8 @@ public class CategoryGraph implements WikiConstants, Serializable {
      */
     private void serializeMap(Map<?,?> map, File file) {
         try {
-            ObjectOutputStream os = new ObjectOutputStream(
-                    new FileOutputStream(file));
+            ObjectOutputStream os = new ObjectOutputStream(new BufferedOutputStream(
+                    new FileOutputStream(file)));
             os.writeObject(map);
             os.close();
         } catch (Exception e) {
@@ -1659,7 +1661,7 @@ public class CategoryGraph implements WikiConstants, Serializable {
     private Map deserializeMap(File file) {
         Map<?,?> map;
         try {
-            ObjectInputStream is = new ObjectInputStream(new FileInputStream(file));
+            ObjectInputStream is = new ObjectInputStream(new BufferedInputStream(new FileInputStream(file)));
             map = (Map<?,?>) is.readObject();
             is.close();
         } catch (Exception e) {

--- a/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/api/util/GraphSerialization.java
+++ b/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/api/util/GraphSerialization.java
@@ -17,6 +17,8 @@
  *******************************************************************************/
 package de.tudarmstadt.ukp.wikipedia.api.util;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -34,81 +36,91 @@ import org.jgrapht.graph.DefaultEdge;
  */
 public final class GraphSerialization {
 
-    /**
-     * This class cannot be instantiated.
-     *
-     */
-    private GraphSerialization() {}
+	/**
+	 * This class cannot be instantiated.
+	 *
+	 */
+	private GraphSerialization() {
+	}
 
+	/**
+	 * Serializes the given DirectedGraph object to the given location.
+	 * 
+	 * @param graph
+	 * @param location
+	 * @throws IOException
+	 */
+	public static void saveGraph(DirectedGraph<Integer, DefaultEdge> graph, String location) throws IOException {
+		File file = new File(location);
+		file.createNewFile();
+		if (!file.canWrite()) {
+			throw new IOException("Cannot write to file " + location);
+		}
+		GraphSerialization.saveGraph(graph, file);
+	}
 
+	/**
+	 * Serializes the given DirectedGraph object to the given location.
+	 * 
+	 * @param graph
+	 * @param file
+	 * @throws IOException
+	 */
+	public static void saveGraph(DirectedGraph<Integer, DefaultEdge> graph, File file) throws IOException {
+		SerializableDirectedGraph serialGraph = new SerializableDirectedGraph(graph);
+		BufferedOutputStream fos = null;
+		ObjectOutputStream out = null;
+		fos = new BufferedOutputStream(new FileOutputStream(file));
+		out = new ObjectOutputStream(fos);
+		out.writeObject(serialGraph);
+		out.close();
 
-    /**
-     * Serializes the given DirectedGraph object to the given location.
-     * @param graph
-     * @param location
-     * @throws IOException
-     */
-    public static void saveGraph(DirectedGraph<Integer,DefaultEdge> graph, String location) throws IOException {
-        File file = new File(location);
-        file.createNewFile();
-        if (!file.canWrite()) {
-            throw new IOException("Cannot write to file " + location);
-        }
-        GraphSerialization.saveGraph(graph, file);
-    }
+	}
 
-    /**
-     * Serializes the given DirectedGraph object to the given location.
-     * @param graph
-     * @param file
-     * @throws IOException
-     */
-    public static void saveGraph(DirectedGraph<Integer,DefaultEdge> graph, File file) throws IOException{
-        SerializableDirectedGraph serialGraph = new SerializableDirectedGraph(graph);
-        FileOutputStream fos = null;
-        ObjectOutputStream out = null;
-        fos = new FileOutputStream(file);
-        out = new ObjectOutputStream(fos);
-        out.writeObject(serialGraph);
-        out.close();
+	/**
+	 * Deserializes a SerializableDirectedGraph object that is stored in the
+	 * given<br>
+	 * location. This method returns the DirectedGraph object, that is wrapped
+	 * in <br>
+	 * the SerializableDirectedGraph.
+	 * 
+	 * @param location
+	 * @return The DirectedGraph object, that is wrapped in the
+	 *         SerializableDirectedGraph.
+	 * @throws IOException
+	 * @throws ClassNotFoundException
+	 * @throws ClassNotFoundException
+	 */
+	public static DirectedGraph<Integer, DefaultEdge> loadGraph(String location)
+			throws IOException, ClassNotFoundException {
+		File file = new File(location);
+		if (!file.canWrite()) {
+			throw new IOException("Cannot read from file " + location);
+		}
+		return GraphSerialization.loadGraph(file);
+	}
 
-    }
-
-    /**
-     * Deserializes a SerializableDirectedGraph object that is stored in the given<br>
-     * location. This method returns the DirectedGraph object, that is wrapped in <br>
-     * the SerializableDirectedGraph.
-     * @param location
-     * @return The DirectedGraph object, that is wrapped in the SerializableDirectedGraph.
-     * @throws IOException
-     * @throws ClassNotFoundException
-     * @throws ClassNotFoundException
-     */
-    public static DirectedGraph<Integer, DefaultEdge> loadGraph(String location) throws IOException, ClassNotFoundException  {
-        File file = new File(location);
-        if (!file.canWrite()) {
-            throw new IOException("Cannot read from file " + location);
-        }
-        return GraphSerialization.loadGraph(file);
-    }
-
-        /**
-     * Deserializes a SerializableDirectedGraph object that is stored in the given<br>
-     * location. This method returns the DirectedGraph object, that is wrapped in <br>
-     * the SerializableDirectedGraph.
-     * @param file
-     * @return The DirectedGraph object, that is wrapped in the SerializableDirectedGraph.
-     * @throws IOException
-     * @throws ClassNotFoundException
-     */
-    public static DirectedGraph<Integer, DefaultEdge> loadGraph(File file) throws IOException, ClassNotFoundException{
-        SerializableDirectedGraph serialGraph = null;
-        FileInputStream fin = null;
-        ObjectInputStream in = null;
-        fin = new FileInputStream(file);
-        in = new ObjectInputStream(fin);
-        serialGraph = (SerializableDirectedGraph) in.readObject();
-        in.close();
-        return serialGraph.getGraph();
-    }
+	/**
+	 * Deserializes a SerializableDirectedGraph object that is stored in the
+	 * given<br>
+	 * location. This method returns the DirectedGraph object, that is wrapped
+	 * in <br>
+	 * the SerializableDirectedGraph.
+	 * 
+	 * @param file
+	 * @return The DirectedGraph object, that is wrapped in the
+	 *         SerializableDirectedGraph.
+	 * @throws IOException
+	 * @throws ClassNotFoundException
+	 */
+	public static DirectedGraph<Integer, DefaultEdge> loadGraph(File file) throws IOException, ClassNotFoundException {
+		SerializableDirectedGraph serialGraph = null;
+		BufferedInputStream fin = null;
+		ObjectInputStream in = null;
+		fin = new BufferedInputStream(new FileInputStream(file));
+		in = new ObjectInputStream(fin);
+		serialGraph = (SerializableDirectedGraph) in.readObject();
+		in.close();
+		return serialGraph.getGraph();
+	}
 }

--- a/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/util/StringUtils.java
+++ b/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/util/StringUtils.java
@@ -18,13 +18,11 @@
 package de.tudarmstadt.ukp.wikipedia.util;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Collection;
 import java.util.Iterator;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -32,59 +30,74 @@ public class StringUtils {
 
 	private static final Log logger = LogFactory.getLog(StringUtils.class);
 
-    /**
-     * Joins the elements of a collection into a string.
-     * @param c The collection which elements should be joined.
-     * @param delimiter String that is introduced between two joined elements.
-     * @return The joined string.
-     */
-    public static String join(Collection c, String delimiter) {
-        StringBuffer buffer = new StringBuffer();
-        Iterator iter = c.iterator();
-        while (iter.hasNext()) {
-            buffer.append(iter.next());
-            if (iter.hasNext()) {
-                buffer.append(delimiter);
-            }
-        }
-        return buffer.toString();
-    }
+	private static final StringBuilder buffer = new StringBuilder(10_000_000);
 
-    public static String getFileContent(String filename, String encoding) {
+	/**
+	 * Joins the elements of a collection into a string.
+	 * 
+	 * @param c
+	 *            The collection which elements should be joined.
+	 * @param delimiter
+	 *            String that is introduced between two joined elements.
+	 * @return The joined string.
+	 */
+	public static String join(Collection c, String delimiter) {
+		buffer.setLength(0);
+		Iterator iter = c.iterator();
+		while (iter.hasNext()) {
+			buffer.append(iter.next());
+			if (iter.hasNext()) {
+				buffer.append(delimiter);
+			}
+		}
+		return buffer.toString();
+	}
 
-        File file = new File(filename);
+	public static String getFileContent(String filename, String encoding) {
 
-        InputStream is;
-        String textContents = "";
-        try {
-            is = new FileInputStream(file);
-            // as the whole file is read at once -> buffering not necessary
-            // InputStream is = new BufferedInputStream(new FileInputStream(file));
-            byte[] contents = new byte[(int) file.length()];
-            is.read(contents);
-            textContents = new String(contents, encoding);
-        } catch (FileNotFoundException e) {
-            logger.error("File " + file.getAbsolutePath() + " not found.");
-            e.printStackTrace();
-        } catch (IOException e) {
-            logger.error("IO exception while reading file " + file.getAbsolutePath());
-            e.printStackTrace();
-        }
+		// File file = new File(filename);
+		//
+		// InputStream is;
+		// String textContents = "";
+		// try {
+		// is = new FileInputStream(file);
+		// // as the whole file is read at once -> buffering not necessary
+		// // InputStream is = new BufferedInputStream(new
+		// FileInputStream(file));
+		// byte[] contents = new byte[(int) file.length()];
+		// is.read(contents);
+		// textContents = new String(contents, encoding);
+		// } catch (FileNotFoundException e) {
+		// logger.error("File " + file.getAbsolutePath() + " not found.");
+		// e.printStackTrace();
+		// } catch (IOException e) {
+		// logger.error("IO exception while reading file " +
+		// file.getAbsolutePath());
+		// e.printStackTrace();
+		// }
+		File file = new File(filename);
+		try {
+			return FileUtils.readFileToString(file, encoding);
+		} catch (IOException e) {
+			logger.error("Exception while reading file " + file.getAbsolutePath());
+			e.printStackTrace();
+			return "";
+		}
 
-        return textContents;
-    }
+	}
 
 	/**
 	 * Replaces all problematic characters from a String with their escaped
 	 * versions to make it SQL conform.
 	 *
-	 * @param str unescaped String
+	 * @param str
+	 *            unescaped String
 	 * @return SQL safe escaped String
 	 */
 	public static String sqlEscape(String str) {
 		final int len = str.length();
-
-		StringBuilder sql = new StringBuilder(len * 2);
+		buffer.setLength(0);
+		StringBuilder sql = buffer;
 
 		for (int i = 0; i < len; i++) {
 			char c = str.charAt(i);
@@ -116,12 +129,12 @@ public class StringUtils {
 			case '\\':
 				sql.append('\\').append('\\');
 				break;
-//			case '%':
-//				sql.append('[').append('%').append(']');
-//				break;
-//			case '_':
-//				sql.append('[').append('_').append(']');
-//				break;
+			// case '%':
+			// sql.append('[').append('%').append(']');
+			// break;
+			// case '_':
+			// sql.append('[').append('_').append(']');
+			// break;
 			default:
 				sql.append(c);
 				break;
@@ -129,6 +142,5 @@ public class StringUtils {
 		}
 		return sql.toString();
 	}
-
 
 }

--- a/de.tudarmstadt.ukp.wikipedia.datamachine/src/main/java/de/tudarmstadt/ukp/wikipedia/datamachine/domain/DataMachineGenerator.java
+++ b/de.tudarmstadt.ukp.wikipedia.datamachine/src/main/java/de/tudarmstadt/ukp/wikipedia/datamachine/domain/DataMachineGenerator.java
@@ -69,8 +69,8 @@ public class DataMachineGenerator extends AbstractSnapshotGenerator {
 		logger.log("parse input dumps...");
 		new XML2Binary(decompressor.getInputStream(getPagesArticlesFile()),
 				files);
-		System.gc();
-
+		
+		
 		dumpVersionProcessor.setDumpVersions(new IDumpVersion[] { version });
 
 		logger.log("processing table page...");

--- a/de.tudarmstadt.ukp.wikipedia.datamachine/src/main/java/de/tudarmstadt/ukp/wikipedia/datamachine/dump/version/SingleDumpVersionJDKGeneric.java
+++ b/de.tudarmstadt.ukp.wikipedia.datamachine/src/main/java/de/tudarmstadt/ukp/wikipedia/datamachine/dump/version/SingleDumpVersionJDKGeneric.java
@@ -67,7 +67,6 @@ public class SingleDumpVersionJDKGeneric<KeyType, HashAlgorithm extends IStringH
 	public void freeAfterCategoryLinksParsing() {
 		cPageIdNameMap.clear();
 		cNamePageIdMap.clear();
-		System.gc();
 	}
 
 	@Override
@@ -108,13 +107,13 @@ public class SingleDumpVersionJDKGeneric<KeyType, HashAlgorithm extends IStringH
 
 	@Override
 	public void initialize(Timestamp timestamp) {
-		pPageIdNameMap = new HashMap<Integer, String>();
-		cPageIdNameMap = new TIntHashSet();
-		pNamePageIdMap = new HashMap<KeyType, Integer>();
-		cNamePageIdMap = new HashMap<KeyType, Integer>();
-		rPageIdNameMap = new HashMap<Integer, String>();
-		disambiguations = new TIntHashSet();
-		textIdPageIdMap = new TIntIntHashMap();
+		pPageIdNameMap = new HashMap<Integer, String>(1_000_000);
+		cPageIdNameMap = new TIntHashSet(1_000_000);
+		pNamePageIdMap = new HashMap<KeyType, Integer>(1_000_000);
+		cNamePageIdMap = new HashMap<KeyType, Integer>(1_000_000);
+		rPageIdNameMap = new HashMap<Integer, String>(1_000_000);
+		disambiguations = new TIntHashSet(1_000_000);
+		textIdPageIdMap = new TIntIntHashMap(1_000_000);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/de.tudarmstadt.ukp.wikipedia.datamachine/src/main/java/de/tudarmstadt/ukp/wikipedia/datamachine/dump/xml/SimpleBinaryDumpWriter.java
+++ b/de.tudarmstadt.ukp.wikipedia.datamachine/src/main/java/de/tudarmstadt/ukp/wikipedia/datamachine/dump/xml/SimpleBinaryDumpWriter.java
@@ -17,6 +17,7 @@
  *******************************************************************************/
 package de.tudarmstadt.ukp.wikipedia.datamachine.dump.xml;
 
+import java.io.BufferedOutputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.zip.GZIPOutputStream;
@@ -41,22 +42,20 @@ public class SimpleBinaryDumpWriter implements DumpWriter {
 	private Revision lastRevision;
 
 	protected void createUncompressed() throws IOException {
-		pageFile = new UTFDataOutputStream(new FileOutputStream(files
-				.getGeneratedPage()));
-		revisionFile = new UTFDataOutputStream(new FileOutputStream(files
-				.getGeneratedRevision()));
-		textFile = new UTFDataOutputStream(new FileOutputStream(files
-				.getGeneratedText()));
+		pageFile = new UTFDataOutputStream(new BufferedOutputStream(new FileOutputStream(files.getGeneratedPage())));
+		revisionFile = new UTFDataOutputStream(
+				new BufferedOutputStream(new FileOutputStream(files.getGeneratedRevision())));
+		textFile = new UTFDataOutputStream(new BufferedOutputStream(new FileOutputStream(files.getGeneratedText())));
 	}
 
 	protected void createCompressed() throws IOException {
 
-		pageFile = new UTFDataOutputStream(new GZIPOutputStream(
-				new FileOutputStream(files.getGeneratedPage())));
-		revisionFile = new UTFDataOutputStream(new GZIPOutputStream(
-				new FileOutputStream(files.getGeneratedRevision())));
-		textFile = new UTFDataOutputStream(new GZIPOutputStream(
-				new FileOutputStream(files.getGeneratedText())));
+		pageFile = new UTFDataOutputStream(
+				new GZIPOutputStream(new BufferedOutputStream(new FileOutputStream(files.getGeneratedPage()))));
+		revisionFile = new UTFDataOutputStream(
+				new GZIPOutputStream(new BufferedOutputStream(new FileOutputStream(files.getGeneratedRevision()))));
+		textFile = new UTFDataOutputStream(
+				new GZIPOutputStream(new BufferedOutputStream(new FileOutputStream(files.getGeneratedText()))));
 
 	}
 
@@ -120,8 +119,7 @@ public class SimpleBinaryDumpWriter implements DumpWriter {
 	private void updatePage(Page page, Revision revision) throws IOException {
 		pageFile.writeInt(page.Id);
 		pageFile.writeInt(page.Title.Namespace);
-		pageFile.writeUTFAsArray(SQLEscape.escape(SQLEscape
-				.titleFormat(page.Title.Text)));
+		pageFile.writeUTFAsArray(SQLEscape.escape(SQLEscape.titleFormat(page.Title.Text)));
 		// pageFile.writeBoolean(revision.isRedirect());
 		pageFile.writeBoolean(Redirects.isRedirect(revision.Text));
 	}

--- a/de.tudarmstadt.ukp.wikipedia.mwdumper/src/main/java/de/tudarmstadt/ukp/wikipedia/mwdumper/importer/ListFilter.java
+++ b/de.tudarmstadt.ukp.wikipedia.mwdumper/src/main/java/de/tudarmstadt/ukp/wikipedia/mwdumper/importer/ListFilter.java
@@ -25,6 +25,7 @@
 
 package de.tudarmstadt.ukp.wikipedia.mwdumper.importer;
 
+import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -37,8 +38,8 @@ public class ListFilter extends PageFilter {
 	public ListFilter(DumpWriter sink, String sourceFileName) throws IOException {
 		super(sink);
 		list = new HashMap();
-		BufferedReader input = new BufferedReader(new InputStreamReader(
-			new FileInputStream(sourceFileName), "utf-8"));
+		BufferedReader input = new BufferedReader(new InputStreamReader(new BufferedInputStream(
+			new FileInputStream(sourceFileName)), "utf-8"));
 		String line = input.readLine();
 		while (line != null) {
 			if (!line.startsWith("#")) {

--- a/de.tudarmstadt.ukp.wikipedia.mwdumper/src/main/java/de/tudarmstadt/ukp/wikipedia/mwdumper/importer/RevisionListFilter.java
+++ b/de.tudarmstadt.ukp.wikipedia.mwdumper/src/main/java/de/tudarmstadt/ukp/wikipedia/mwdumper/importer/RevisionListFilter.java
@@ -26,6 +26,7 @@
 package de.tudarmstadt.ukp.wikipedia.mwdumper.importer;
 
 import java.lang.Integer;
+import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -41,8 +42,8 @@ public class RevisionListFilter implements DumpWriter {
 	public RevisionListFilter(DumpWriter sink, String sourceFileName) throws IOException {
 		this.sink = sink;
 		revIds = new TreeSet();
-		BufferedReader input = new BufferedReader(new InputStreamReader(
-			new FileInputStream(sourceFileName), "utf-8"));
+		BufferedReader input = new BufferedReader(new InputStreamReader(new BufferedInputStream(
+			new FileInputStream(sourceFileName)), "utf-8"));
 		String line = input.readLine();
 		while (line != null) {
 			line = line.trim();

--- a/de.tudarmstadt.ukp.wikipedia.mwdumper/src/main/java/de/tudarmstadt/ukp/wikipedia/mwdumper/importer/XmlDumpReader.java
+++ b/de.tudarmstadt.ukp.wikipedia.mwdumper/src/main/java/de/tudarmstadt/ukp/wikipedia/mwdumper/importer/XmlDumpReader.java
@@ -33,7 +33,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;

--- a/de.tudarmstadt.ukp.wikipedia.mwdumper/src/main/java/de/tudarmstadt/ukp/wikipedia/mwdumper/importer/XmlDumpReader.java
+++ b/de.tudarmstadt.ukp.wikipedia.mwdumper/src/main/java/de/tudarmstadt/ukp/wikipedia/mwdumper/importer/XmlDumpReader.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;

--- a/de.tudarmstadt.ukp.wikipedia.parser/src/main/java/de/tudarmstadt/ukp/wikipedia/parser/html/HtmlWriter.java
+++ b/de.tudarmstadt.ukp.wikipedia.parser/src/main/java/de/tudarmstadt/ukp/wikipedia/parser/html/HtmlWriter.java
@@ -17,6 +17,7 @@
  *******************************************************************************/
 package de.tudarmstadt.ukp.wikipedia.parser.html;
 
+import java.io.BufferedOutputStream;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -487,8 +488,8 @@ public class HtmlWriter {
         File outFile = new File(filename);
         Writer destFile = null;
         try {
-            destFile = new BufferedWriter(new OutputStreamWriter(
-                            new FileOutputStream(outFile), encoding));
+            destFile = new BufferedWriter(new OutputStreamWriter(new BufferedOutputStream(
+                            new FileOutputStream(outFile)), encoding));
         } catch (UnsupportedEncodingException e1) {
             logger.error("Unsupported encoding exception while opening file " + outFile.getAbsolutePath());
             e1.printStackTrace();

--- a/de.tudarmstadt.ukp.wikipedia.revisionmachine/src/main/java/de/tudarmstadt/ukp/wikipedia/revisionmachine/api/chrono/ChronoStorage.java
+++ b/de.tudarmstadt.ukp.wikipedia.revisionmachine/src/main/java/de/tudarmstadt/ukp/wikipedia/revisionmachine/api/chrono/ChronoStorage.java
@@ -328,7 +328,7 @@ public class ChronoStorage
 			last = block;
 		}
 
-		System.gc();
+		
 	}
 
 	/**

--- a/de.tudarmstadt.ukp.wikipedia.revisionmachine/src/main/java/de/tudarmstadt/ukp/wikipedia/revisionmachine/archivers/Bzip2Archiver.java
+++ b/de.tudarmstadt.ukp.wikipedia.revisionmachine/src/main/java/de/tudarmstadt/ukp/wikipedia/revisionmachine/archivers/Bzip2Archiver.java
@@ -55,7 +55,7 @@ public class Bzip2Archiver
 
 			File fileToArchive = new File(path);
 
-			FileInputStream input = new FileInputStream(fileToArchive);
+			BufferedInputStream input = new BufferedInputStream(new FileInputStream(fileToArchive));
 
 			File archivedFile = new File(fileToArchive.getName() + ".bz2");
 			archivedFile.createNewFile();
@@ -130,7 +130,7 @@ public class Bzip2Archiver
 	{
 		File fileToUncompress = new File(path);
 
-		FileInputStream fileStream = new FileInputStream(fileToUncompress);
+		BufferedInputStream fileStream = new BufferedInputStream(new FileInputStream(fileToUncompress));
 
 		// read bzip2 prefix: BZ
 		fileStream.read();
@@ -161,7 +161,7 @@ public class Bzip2Archiver
 
 		unarchived.createNewFile();
 
-		FileInputStream inputStr = new FileInputStream(bzip2);
+		BufferedInputStream inputStr = new BufferedInputStream(new FileInputStream(bzip2));
 
 		// read bzip2 prefix
 		inputStr.read();

--- a/de.tudarmstadt.ukp.wikipedia.revisionmachine/src/main/java/de/tudarmstadt/ukp/wikipedia/revisionmachine/common/util/WikipediaXMLWriter.java
+++ b/de.tudarmstadt.ukp.wikipedia.revisionmachine/src/main/java/de/tudarmstadt/ukp/wikipedia/revisionmachine/common/util/WikipediaXMLWriter.java
@@ -17,6 +17,7 @@
  *******************************************************************************/
 package de.tudarmstadt.ukp.wikipedia.revisionmachine.common.util;
 
+import java.io.BufferedOutputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
@@ -56,7 +57,7 @@ public class WikipediaXMLWriter
 	public WikipediaXMLWriter(final String path)
 		throws IOException
 	{
-		this.writer = new OutputStreamWriter(new FileOutputStream(path),
+		this.writer = new OutputStreamWriter(new BufferedOutputStream(new FileOutputStream(path)),
 				"UTF-8");
 	}
 

--- a/de.tudarmstadt.ukp.wikipedia.revisionmachine/src/main/java/de/tudarmstadt/ukp/wikipedia/revisionmachine/difftool/DiffToolThread.java
+++ b/de.tudarmstadt.ukp.wikipedia.revisionmachine/src/main/java/de/tudarmstadt/ukp/wikipedia/revisionmachine/difftool/DiffToolThread.java
@@ -287,7 +287,6 @@ public class DiffToolThread
 
 			while (archives.hasArchive()) {
 
-				System.gc();
 
 				// Retrieve Archive
 				try {

--- a/de.tudarmstadt.ukp.wikipedia.revisionmachine/src/main/java/de/tudarmstadt/ukp/wikipedia/revisionmachine/difftool/consumer/article/reader/InputFactory.java
+++ b/de.tudarmstadt.ukp.wikipedia.revisionmachine/src/main/java/de/tudarmstadt/ukp/wikipedia/revisionmachine/difftool/consumer/article/reader/InputFactory.java
@@ -17,6 +17,7 @@
  *******************************************************************************/
 package de.tudarmstadt.ukp.wikipedia.revisionmachine.difftool.consumer.article.reader;
 
+import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -151,7 +152,7 @@ public class InputFactory
 	{
 
 		try {
-			return new InputStreamReader(new FileInputStream(archivePath),
+			return new InputStreamReader(new BufferedInputStream(new FileInputStream(archivePath)),
 					WIKIPEDIA_ENCODING);
 
 		}

--- a/de.tudarmstadt.ukp.wikipedia.revisionmachine/src/main/java/de/tudarmstadt/ukp/wikipedia/revisionmachine/difftool/consumer/dump/writer/DataFileWriter.java
+++ b/de.tudarmstadt.ukp.wikipedia.revisionmachine/src/main/java/de/tudarmstadt/ukp/wikipedia/revisionmachine/difftool/consumer/dump/writer/DataFileWriter.java
@@ -17,6 +17,7 @@
  *******************************************************************************/
 package de.tudarmstadt.ukp.wikipedia.revisionmachine.difftool.consumer.dump.writer;
 
+import java.io.BufferedOutputStream;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -244,8 +245,8 @@ public class DataFileWriter
 
 		this.dataFile = new File(filePath);
 
-		this.writer = new BufferedWriter(new OutputStreamWriter(
-		        new FileOutputStream(filePath), WIKIPEDIA_ENCODING));
+		this.writer = new BufferedWriter(new OutputStreamWriter(new BufferedOutputStream(
+		        new FileOutputStream(filePath)), WIKIPEDIA_ENCODING));
 
 
 		this.writer.flush();

--- a/de.tudarmstadt.ukp.wikipedia.revisionmachine/src/main/java/de/tudarmstadt/ukp/wikipedia/revisionmachine/difftool/consumer/dump/writer/SQLFileWriter.java
+++ b/de.tudarmstadt.ukp.wikipedia.revisionmachine/src/main/java/de/tudarmstadt/ukp/wikipedia/revisionmachine/difftool/consumer/dump/writer/SQLFileWriter.java
@@ -17,6 +17,7 @@
  *******************************************************************************/
 package de.tudarmstadt.ukp.wikipedia.revisionmachine.difftool.consumer.dump.writer;
 
+import java.io.BufferedOutputStream;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -255,8 +256,8 @@ public class SQLFileWriter
 
 		this.sqlFile = new File(filePath);
 
-		this.writer = new BufferedWriter(new OutputStreamWriter(
-		        new FileOutputStream(filePath), WIKIPEDIA_ENCODING));
+		this.writer = new BufferedWriter(new OutputStreamWriter(new BufferedOutputStream(
+		        new FileOutputStream(filePath)), WIKIPEDIA_ENCODING));
 
 ;
 

--- a/de.tudarmstadt.ukp.wikipedia.revisionmachine/src/main/java/de/tudarmstadt/ukp/wikipedia/revisionmachine/index/IndexGenerator.java
+++ b/de.tudarmstadt.ukp.wikipedia.revisionmachine/src/main/java/de/tudarmstadt/ukp/wikipedia/revisionmachine/index/IndexGenerator.java
@@ -17,6 +17,7 @@
  *******************************************************************************/
 package de.tudarmstadt.ukp.wikipedia.revisionmachine.index;
 
+import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -212,10 +213,10 @@ public class IndexGenerator
 	private static Properties load(String configFilePath)
 	{
 		Properties props = new Properties();
-		FileInputStream fis = null;
+		BufferedInputStream fis = null;
 		try {
 			File configFile = new File(configFilePath);
-	        fis = new FileInputStream(configFile);
+	        fis = new BufferedInputStream(new FileInputStream(configFile));
 	        props.load(fis);
         }
         catch(IOException e){

--- a/de.tudarmstadt.ukp.wikipedia.timemachine/src/main/java/de/tudarmstadt/ukp/wikipedia/timemachine/domain/SettingsXML.java
+++ b/de.tudarmstadt.ukp.wikipedia.timemachine/src/main/java/de/tudarmstadt/ukp/wikipedia/timemachine/domain/SettingsXML.java
@@ -17,6 +17,8 @@
  *******************************************************************************/
 package de.tudarmstadt.ukp.wikipedia.timemachine.domain;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -62,7 +64,7 @@ public class SettingsXML {
 		p.put(PAGE_LINKS_FILE, PLACEHOLDER);
 		p.put(CATEGORY_LINKS_FILE, PLACEHOLDER);
 		p.put(OUTPUT_DIRECTORY, PLACEHOLDER);
-		p.storeToXML(new FileOutputStream(outputFileName), DESCRIPTION);
+		p.storeToXML(new BufferedOutputStream(new FileOutputStream(outputFileName)), DESCRIPTION);
 
 	}
 
@@ -73,7 +75,7 @@ public class SettingsXML {
 		try {
 			result = new Configuration(logger);
 			Properties properties = new Properties();
-			properties.loadFromXML(new FileInputStream(configFile));
+			properties.loadFromXML(new BufferedInputStream(new FileInputStream(configFile)));
 
 			result.setLanguage(properties.get(LANGUAGE).toString());
 			result.setMainCategory(properties.get(MAIN_CATEGORY).toString());
@@ -94,7 +96,7 @@ public class SettingsXML {
 		TimeMachineFiles result;
 		try {
 			Properties properties = new Properties();
-			properties.loadFromXML(new FileInputStream(configFile));
+			properties.loadFromXML(new BufferedInputStream(new FileInputStream(configFile)));
 			result = new TimeMachineFiles(logger);
 
 			result.setMetaHistoryFile(properties.get(META_HISTORY_FILE)

--- a/de.tudarmstadt.ukp.wikipedia.util/src/main/java/de/tudarmstadt/ukp/wikipedia/util/templates/generator/simple/TemplateInfoGeneratorStarter.java
+++ b/de.tudarmstadt.ukp.wikipedia.util/src/main/java/de/tudarmstadt/ukp/wikipedia/util/templates/generator/simple/TemplateInfoGeneratorStarter.java
@@ -17,6 +17,7 @@
  *******************************************************************************/
 package de.tudarmstadt.ukp.wikipedia.util.templates.generator.simple;
 
+import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -213,10 +214,10 @@ public class TemplateInfoGeneratorStarter
 	private static Properties load(String configFilePath)
 	{
 		Properties props = new Properties();
-		FileInputStream fis = null;
+		BufferedInputStream fis = null;
 		try {
 			File configFile = new File(configFilePath);
-			fis = new FileInputStream(configFile);
+			fis = new BufferedInputStream(new FileInputStream(configFile));
 			props.load(fis);
 		}
 		catch (IOException e) {

--- a/de.tudarmstadt.ukp.wikipedia.util/src/main/java/de/tudarmstadt/ukp/wikipedia/util/templates/generator/simple/WikipediaTemplateInfoDumpWriter.java
+++ b/de.tudarmstadt.ukp.wikipedia.util/src/main/java/de/tudarmstadt/ukp/wikipedia/util/templates/generator/simple/WikipediaTemplateInfoDumpWriter.java
@@ -17,6 +17,7 @@
  *******************************************************************************/
 package de.tudarmstadt.ukp.wikipedia.util.templates.generator.simple;
 
+import java.io.BufferedOutputStream;
 import java.io.BufferedWriter;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -231,8 +232,8 @@ public class WikipediaTemplateInfoDumpWriter
 	{
 		Writer writer = null;
 		try {
-			writer = new BufferedWriter(new OutputStreamWriter(
-					new FileOutputStream(outputPath), charset));
+			writer = new BufferedWriter(new OutputStreamWriter(new BufferedOutputStream(
+					new FileOutputStream(outputPath)), charset));
 			StringBuffer dataToDump = new StringBuffer();
 
 			dataToDump.append(generateTemplateIdSQLStatement(this.tableExists));

--- a/de.tudarmstadt.ukp.wikipedia.wikimachine/src/main/java/de/tudarmstadt/ukp/wikipedia/wikimachine/debug/FileMemoryLogger.java
+++ b/de.tudarmstadt.ukp.wikipedia.wikimachine/src/main/java/de/tudarmstadt/ukp/wikipedia/wikimachine/debug/FileMemoryLogger.java
@@ -17,6 +17,7 @@
  *******************************************************************************/
 package de.tudarmstadt.ukp.wikipedia.wikimachine.debug;
 
+import java.io.BufferedOutputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
@@ -46,8 +47,8 @@ public class FileMemoryLogger extends AbstractLogger {
 	public FileMemoryLogger() {
 
 		try {
-			output = new PrintStream(new FileOutputStream(FILENAME_FORMAT
-					.format(new Date()).concat(".txt")));
+			output = new PrintStream(new BufferedOutputStream(new FileOutputStream(FILENAME_FORMAT
+					.format(new Date()).concat(".txt"))));
 			output.println(FILEHEADER);
 		} catch (FileNotFoundException e) {
 			log4j.error(e.getMessage());

--- a/de.tudarmstadt.ukp.wikipedia.wikimachine/src/main/java/de/tudarmstadt/ukp/wikipedia/wikimachine/decompression/BZip2Decompressor.java
+++ b/de.tudarmstadt.ukp.wikipedia.wikimachine/src/main/java/de/tudarmstadt/ukp/wikipedia/wikimachine/decompression/BZip2Decompressor.java
@@ -17,6 +17,7 @@
  *******************************************************************************/
 package de.tudarmstadt.ukp.wikipedia.wikimachine.decompression;
 
+import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -33,10 +34,10 @@ public class BZip2Decompressor implements IDecompressor {
 
 	@Override
 	public InputStream getInputStream(String fileName) throws IOException {
-		FileInputStream inputStream;
+		BufferedInputStream inputStream;
 		InputStream outputStream = null;
 
-		inputStream = new FileInputStream(fileName);
+		inputStream = new BufferedInputStream(new FileInputStream(fileName));
 		/**
 		 * skip 2 first bytes (see the documentation of CBZip2InputStream) e.g.
 		 * here http://lucene.apache.org/tika/xref/org/apache/tika/parser

--- a/de.tudarmstadt.ukp.wikipedia.wikimachine/src/main/java/de/tudarmstadt/ukp/wikipedia/wikimachine/decompression/UniversalDecompressor.java
+++ b/de.tudarmstadt.ukp.wikipedia.wikimachine/src/main/java/de/tudarmstadt/ukp/wikipedia/wikimachine/decompression/UniversalDecompressor.java
@@ -17,6 +17,7 @@
  *******************************************************************************/
 package de.tudarmstadt.ukp.wikipedia.wikimachine.decompression;
 
+import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -174,7 +175,7 @@ public class UniversalDecompressor implements IDecompressor {
 	private InputStream getDefault(String fileName) {
 		InputStream result = null;
 		try {
-			result = new FileInputStream(fileName);
+			result = new BufferedInputStream(new FileInputStream(fileName));
 		} catch (IOException ignore) {
 		}
 

--- a/de.tudarmstadt.ukp.wikipedia.wikimachine/src/main/java/de/tudarmstadt/ukp/wikipedia/wikimachine/domain/DumpVersionProcessor.java
+++ b/de.tudarmstadt.ukp.wikipedia.wikimachine/src/main/java/de/tudarmstadt/ukp/wikipedia/wikimachine/domain/DumpVersionProcessor.java
@@ -31,7 +31,7 @@ public class DumpVersionProcessor {
 
 	private static ILogger logger;
 
-	private Integer step2Log = 10000;
+	private Integer step2Log = 100000;
 	private Integer step2GC = step2Log * 10;
 	private Integer step2Flush = step2GC;
 
@@ -181,9 +181,6 @@ public class DumpVersionProcessor {
 		if (step2Log != 0 && counter % step2Log == 0) {
 			String message = event + " " + counter;
 			logger.log(message);
-		}
-		if (step2GC != 0 && counter % step2GC == 0) {
-			System.gc();
 		}
 	}
 

--- a/de.tudarmstadt.ukp.wikipedia.wikimachine/src/main/java/de/tudarmstadt/ukp/wikipedia/wikimachine/dump/xml/AbstractXmlDumpReader.java
+++ b/de.tudarmstadt.ukp.wikipedia.wikimachine/src/main/java/de/tudarmstadt/ukp/wikipedia/wikimachine/dump/xml/AbstractXmlDumpReader.java
@@ -32,7 +32,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;

--- a/de.tudarmstadt.ukp.wikipedia.wikimachine/src/main/java/de/tudarmstadt/ukp/wikipedia/wikimachine/dump/xml/AbstractXmlDumpReader.java
+++ b/de.tudarmstadt.ukp.wikipedia.wikimachine/src/main/java/de/tudarmstadt/ukp/wikipedia/wikimachine/dump/xml/AbstractXmlDumpReader.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;

--- a/de.tudarmstadt.ukp.wikipedia.wikimachine/src/main/java/de/tudarmstadt/ukp/wikipedia/wikimachine/util/TxtFileWriter.java
+++ b/de.tudarmstadt.ukp.wikipedia.wikimachine/src/main/java/de/tudarmstadt/ukp/wikipedia/wikimachine/util/TxtFileWriter.java
@@ -17,6 +17,7 @@
  *******************************************************************************/
 package de.tudarmstadt.ukp.wikipedia.wikimachine.util;
 
+import java.io.BufferedOutputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -39,7 +40,7 @@ public class TxtFileWriter extends PrintStream {
 	 * @throws IOException
 	 */
 	public TxtFileWriter(String filename) throws IOException {
-		super(new FileOutputStream(filename), AUTOFLUSH, ENCODING);
+		super(new BufferedOutputStream(new FileOutputStream(filename)), AUTOFLUSH, ENCODING);
 	}
 
 	/**


### PR DESCRIPTION
### Description

This commit reduces drastically the computation time to prepare the JWPL datasets (creating the txt files to be imported in MySQL). It has been tested on the _english_ and _simple english_ dumps, **dividing computation time by a factor between 12 and 14**.
On the _english_ dump (bz2 compressed), this version requires 2 hours against more than 25 hours. For _simple english_, the required time is around one minute instead of twelve.

If this PR is to be accepted, since this is a major commit, I'll send you a signed version of the CLA

### Changes
- Buffered FileInput/Output all the way: all the file accesses are now buffered, this is the main speedup factor.
- Change Stringbuffer to stringbuilder (code is single threaded)
- Avoid creation of SB at every join call: the method join() in StringUtils is widely used and created a stringbuilder at each call, leading to useless memory reallocation and garbage collection. Since the code is single threaded, a single static stringbuilder is used. 
- Remove every GC call: there were plenty of System.gc() calls, something that should be avoided at all cost. Removing this calls, led to a very significant improvement, notably on large datasets such as the _english_ dump.

