### PR TITLE
#174 - Query did not return a unique result for "existsPage(String title)" after introduction of HSQL-DB tests

### DIFF
--- a/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/api/Category.java
+++ b/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/api/Category.java
@@ -108,9 +108,12 @@ public class Category implements WikiConstants {
         session.beginTransaction();
 
         Object returnValue;
-        /* XXX this query was mysql specific before using "COLLATE utf8_bin" at the end. */
-        returnValue = session.createNativeQuery(
-                "select cat.pageId from Category as cat where cat.name = :name")
+
+        String query = "select cat.pageId from Category as cat where cat.name = :name ";
+        if(wiki.getDatabaseConfiguration().supportsCollation()) {
+            query += Wikipedia.SQL_COLLATION;
+        }
+        returnValue = session.createNativeQuery(query)
                 .setParameter("name", name, StringType.INSTANCE)
                 .uniqueResult();
         session.getTransaction().commit();

--- a/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/api/Category.java
+++ b/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/api/Category.java
@@ -109,7 +109,7 @@ public class Category implements WikiConstants {
 
         Object returnValue;
 
-        String query = "select cat.pageId from Category as cat where cat.name = :name ";
+        String query = "select cat.pageId from Category as cat where cat.name = :name";
         if(wiki.getDatabaseConfiguration().supportsCollation()) {
             query += Wikipedia.SQL_COLLATION;
         }

--- a/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/api/DatabaseConfiguration.java
+++ b/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/api/DatabaseConfiguration.java
@@ -73,6 +73,17 @@ public class DatabaseConfiguration {
     }
 
     /**
+     * @return {@code True} if collation is supported by the database backend, else {@code false}.
+     */
+    boolean supportsCollation() {
+        if(databaseDriver!=null) {
+            return databaseDriver.contains("mysql");
+        } else {
+            return false;
+        }
+    }
+
+    /**
      * @param database The name of the database.
      */
     public void setDatabase(String database) {
@@ -156,4 +167,5 @@ public class DatabaseConfiguration {
 	public String getJdbcURL() {
 		return jdbcURL;
 	}
+
 }

--- a/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/api/Wikipedia.java
+++ b/de.tudarmstadt.ukp.wikipedia.api/src/main/java/de/tudarmstadt/ukp/wikipedia/api/Wikipedia.java
@@ -51,7 +51,8 @@ import org.sweble.wikitext.engine.config.WikiConfig;
 // TODO better JavaDocs!
 public class Wikipedia implements WikiConstants {
 
-    static final String SQL_COLLATION = "COLLATE utf8_bin";
+    // Note well: The whitespace at the beginning of this constant is here on purpose. Do NOT remove it!
+    static final String SQL_COLLATION = " COLLATE utf8_bin";
 
 	private final Log logger = LogFactory.getLog(getClass());
     private final Language language;
@@ -635,7 +636,7 @@ public class Wikipedia implements WikiConstants {
 
     	Session session = this.__getHibernateSession();
         session.beginTransaction();
-        String query = "select p.id from PageMapLine as p where p.name = :pName ";
+        String query = "select p.id from PageMapLine as p where p.name = :pName";
         if(dbConfig.supportsCollation()) {
             query += SQL_COLLATION;
         }


### PR DESCRIPTION
- Addresses the broken MySQL collation for two cases: `Wikipedia#existsPage(name)` and `Category.createCategory(title)`. The latter case was also affected.

Please review the PR and approve it as it fixes a regression.

Fixes #174