### PR TITLE
#176 - Modernize JWPL maven plugins and related tooling via update to dkpro-parent-pom version 19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.dkpro</groupId>
     <artifactId>dkpro-parent-pom</artifactId>
-    <version>15</version>
+    <version>19</version>
   </parent>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
- Updates `dkpro-parent-pom` to version 19.

Build works fine locally. It's like 1, 2, 3. (: