### PR TITLE
#241 Update dependency Spring to version 6.x

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        java: [ 11, 17, 21 ]
+        java: [ 17, 21 ]
         experimental: [false]
 
     steps:

--- a/dkpro-jwpl-wikimachine/pom.xml
+++ b/dkpro-jwpl-wikimachine/pom.xml
@@ -35,6 +35,10 @@
             <artifactId>spring-beans</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.dkpro.jwpl</groupId>
             <artifactId>dkpro-jwpl-mwdumper</artifactId>
         </dependency>

--- a/dkpro-jwpl-wikimachine/src/main/java/org/dkpro/jwpl/wikimachine/factory/SpringFactory.java
+++ b/dkpro-jwpl-wikimachine/src/main/java/org/dkpro/jwpl/wikimachine/factory/SpringFactory.java
@@ -2,13 +2,13 @@
  * Licensed to the Technische Universität Darmstadt under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
- * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * regarding copyright ownership.  The Technische Universität Darmstadt
  * licenses this file to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.
- *  
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,10 +20,9 @@ package org.dkpro.jwpl.wikimachine.factory;
 import java.io.File;
 
 import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.xml.XmlBeanFactory;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.FileSystemResource;
-import org.springframework.core.io.Resource;
+import org.springframework.context.support.AbstractXmlApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.context.support.FileSystemXmlApplicationContext;
 
 import org.dkpro.jwpl.wikimachine.debug.ILogger;
 import org.dkpro.jwpl.wikimachine.decompression.IDecompressor;
@@ -37,88 +36,95 @@ import org.dkpro.jwpl.wikimachine.dump.xml.TextParser;
 
 public class SpringFactory implements IEnvironmentFactory {
 
-	private static final String INNER_APPLICATION_CONTEXT = "context/applicationContext.xml";
+  private static final String INNER_APPLICATION_CONTEXT = "context/applicationContext.xml";
 
-	private static final String OUTER_APPLICATION_CONTEXT = "applicationContext.xml";
+  private static final String OUTER_APPLICATION_CONTEXT = "applicationContext.xml";
 
-	private static final String LOG_BEAN = "logger";
+  private static final String LOG_BEAN = "logger";
 
-	private static final String DECOMPRESSOR_BEAN = "decompressor";
+  private static final String DECOMPRESSOR_BEAN = "decompressor";
 
-	private static final String DUMPVERSIONPROCESSOR_BEAN = "dumpVersionProcessor";
+  private static final String DUMPVERSIONPROCESSOR_BEAN = "dumpVersionProcessor";
 
-	private static final String PAGEPARSER_BEAN = "pageParser";
+  private static final String PAGEPARSER_BEAN = "pageParser";
 
-	private static final String SNAPSHOTGENERATOR_BEAN = "snapshotGenerator";
+  private static final String SNAPSHOTGENERATOR_BEAN = "snapshotGenerator";
 
-	private static final String REVISIONPARSER_BEAN = "revisionParser";
+  private static final String REVISIONPARSER_BEAN = "revisionParser";
 
-	private static final String TEXTPARSER_BEAN = "textParser";
+  private static final String TEXTPARSER_BEAN = "textParser";
 
-	private static final String DUMPVERSION_BEAN = "dumpVersion";
+  private static final String DUMPVERSION_BEAN = "dumpVersion";
 
-	private static final String DUMPTABLEINPUTSTREAM_BEAN = "dumpTableInputStream";
+  private static final String DUMPTABLEINPUTSTREAM_BEAN = "dumpTableInputStream";
 
-	private static final BeanFactory factory = getBeanFactory();
+  private static final BeanFactory factory = getBeanFactory();
 
-	private static final SpringFactory instance = new SpringFactory();
+  private static final SpringFactory instance = new SpringFactory();
 
-	private static BeanFactory getBeanFactory() {
-		File outerContextFile = new File(OUTER_APPLICATION_CONTEXT);
-		boolean outerContextFileProper = outerContextFile.exists()
-				&& outerContextFile.isFile() && outerContextFile.canRead();
-		Resource res = (outerContextFileProper) ? new FileSystemResource(outerContextFile) :
-						new ClassPathResource(INNER_APPLICATION_CONTEXT);
-		return new XmlBeanFactory(res);
-	}
+  private static BeanFactory getBeanFactory() {
+    File outerContextFile = new File(OUTER_APPLICATION_CONTEXT);
+    boolean outerContextFileProper = outerContextFile.exists()
+            && outerContextFile.isFile() && outerContextFile.canRead();
 
-	public static SpringFactory getInstance() {
-		return instance;
-	}
+    AbstractXmlApplicationContext ctx;
+    if (outerContextFileProper) {
+      ctx = new FileSystemXmlApplicationContext(OUTER_APPLICATION_CONTEXT);
+    } else {
+      ctx = new ClassPathXmlApplicationContext(INNER_APPLICATION_CONTEXT);
+    }
+    return ctx;
+  }
 
-	public ILogger getLogger() {
-		return (ILogger) factory.getBean(LOG_BEAN);
-	}
+  public static SpringFactory getInstance() {
+    return instance;
+  }
 
-	public IDecompressor getDecompressor() {
-		return (IDecompressor) factory.getBean(DECOMPRESSOR_BEAN);
-	}
+  @Override
+  public ILogger getLogger() {
+    return (ILogger) factory.getBean(LOG_BEAN);
+  }
 
-	@Override
-	public ISnapshotGenerator getSnapshotGenerator() {
-		return (ISnapshotGenerator) factory.getBean(SNAPSHOTGENERATOR_BEAN);
-	}
+  @Override
+  public IDecompressor getDecompressor() {
+    return (IDecompressor) factory.getBean(DECOMPRESSOR_BEAN);
+  }
 
-	@Override
-	public DumpVersionProcessor getDumpVersionProcessor() {
-		return (DumpVersionProcessor) factory
-				.getBean(DUMPVERSIONPROCESSOR_BEAN);
-	}
+  @Override
+  public ISnapshotGenerator getSnapshotGenerator() {
+    return (ISnapshotGenerator) factory.getBean(SNAPSHOTGENERATOR_BEAN);
+  }
 
-	@Override
-	public IDumpVersion getDumpVersion() {
-		return (IDumpVersion) factory.getBean(DUMPVERSION_BEAN);
-	}
+  @Override
+  public DumpVersionProcessor getDumpVersionProcessor() {
+    return (DumpVersionProcessor) factory
+            .getBean(DUMPVERSIONPROCESSOR_BEAN);
+  }
 
-	@Override
-	public DumpTableInputStream getDumpTableInputStream() {
-		return (DumpTableInputStream) factory
-				.getBean(DUMPTABLEINPUTSTREAM_BEAN);
-	}
+  @Override
+  public IDumpVersion getDumpVersion() {
+    return (IDumpVersion) factory.getBean(DUMPVERSION_BEAN);
+  }
 
-	@Override
-	public PageParser getPageParser() {
-		return (PageParser) factory.getBean(PAGEPARSER_BEAN);
-	}
+  @Override
+  public DumpTableInputStream getDumpTableInputStream() {
+    return (DumpTableInputStream) factory
+            .getBean(DUMPTABLEINPUTSTREAM_BEAN);
+  }
 
-	@Override
-	public RevisionParser getRevisionParser() {
-		return (RevisionParser) factory.getBean(REVISIONPARSER_BEAN);
-	}
+  @Override
+  public PageParser getPageParser() {
+    return (PageParser) factory.getBean(PAGEPARSER_BEAN);
+  }
 
-	@Override
-	public TextParser getTextParser() {
-		return (TextParser) factory.getBean(TEXTPARSER_BEAN);
-	}
+  @Override
+  public RevisionParser getRevisionParser() {
+    return (RevisionParser) factory.getBean(REVISIONPARSER_BEAN);
+  }
+
+  @Override
+  public TextParser getTextParser() {
+    return (TextParser) factory.getBean(TEXTPARSER_BEAN);
+  }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,9 @@
     <fau.utils.version>3.0.8</fau.utils.version>
     <org.sweble.wikitext.version>3.1.9</org.sweble.wikitext.version>
 
-    <spring.version>5.3.30</spring.version>
-
+    <spring.version>6.0.13</spring.version>
+    <commons.lang3.version>3.13.0</commons.lang3.version>
+    
     <!-- DB specific dependency versions -->
     <hibernate.version>6.1.7.Final</hibernate.version>
     <mysql.version>5.1.44</mysql.version>
@@ -154,6 +155,11 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-beans</artifactId>
+        <version>${spring.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-context</artifactId>
         <version>${spring.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
- updates Spring dependencies to version 6.0.13
- adds necessary references to `spring-context` in wikimachine pom.xml
- removes reference to `XmlBeanFactory` in `SpringFactory` as this interface was long-time deprecated and removed in Spring 6.x