### PR TITLE
#245 Remove unused method binding to commons.io dependency in API module

### DIFF
--- a/dkpro-jwpl-api/pom.xml
+++ b/dkpro-jwpl-api/pom.xml
@@ -54,10 +54,6 @@
 			<artifactId>ptk-common</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>commons-logging</groupId>
-			<artifactId>commons-logging</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.sweble.wikitext</groupId>
 			<artifactId>swc-parser-lazy</artifactId>
 		</dependency>

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/util/StringUtils.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/util/StringUtils.java
@@ -17,13 +17,10 @@
  */
 package org.dkpro.jwpl.util;
 
-import java.io.File;
-import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.Collection;
 import java.util.Iterator;
 
-import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,38 +49,6 @@ public class StringUtils {
 			}
 		}
 		return buffer.toString();
-	}
-
-	public static String getFileContent(String filename, String encoding) {
-
-		// File file = new File(filename);
-		//
-		// InputStream is;
-		// String textContents = "";
-		// try {
-		// is = new FileInputStream(file);
-		// // as the whole file is read at once -> buffering not necessary
-		// // InputStream is = new BufferedInputStream(new
-		// FileInputStream(file));
-		// byte[] contents = new byte[(int) file.length()];
-		// is.read(contents);
-		// textContents = new String(contents, encoding);
-		// } catch (FileNotFoundException e) {
-		// logger.error("File " + file.getAbsolutePath() + " not found.");
-		// e.printStackTrace();
-		// } catch (IOException e) {
-		// logger.error("IO exception while reading file " +
-		// file.getAbsolutePath());
-		// e.printStackTrace();
-		// }
-		File file = new File(filename);
-		try {
-			return FileUtils.readFileToString(file, encoding);
-		} catch (IOException e) {
-			logger.error("Exception while reading file " + file.getAbsolutePath(), e);
-			return "";
-		}
-
 	}
 
 	/**

--- a/dkpro-jwpl-deps/dkpro-jwpl-swc-engine-shade/pom.xml
+++ b/dkpro-jwpl-deps/dkpro-jwpl-swc-engine-shade/pom.xml
@@ -36,11 +36,13 @@
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
             <version>3.2.2</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>1.4</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>de.fau.cs.osr.ptk</groupId>


### PR DESCRIPTION
- gets rid of that piece of leftover code in `StringUtils` and dependency towards commons-io class(es)
- declares two outdated dependency in swc-engine shade as 'runtime'-scoped to avoid accidental compile dependency in API module