### PR TITLE
#249 Remove commons-codec dependency in favor of JDK's own Base64 codec

### DIFF
--- a/dkpro-jwpl-revisionmachine/pom.xml
+++ b/dkpro-jwpl-revisionmachine/pom.xml
@@ -31,14 +31,10 @@
   		<groupId>org.dkpro.jwpl</groupId>
   		<artifactId>dkpro-jwpl-api</artifactId>
   	</dependency>
-  	<dependency>
-  		<groupId>commons-codec</groupId>
-  		<artifactId>commons-codec</artifactId>
-  	</dependency>
-	<dependency>
-		<groupId>org.apache.commons</groupId>
-		<artifactId>commons-compress</artifactId>
-	</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-compress</artifactId>
+		</dependency>
 	  <dependency>
 		  <groupId>org.slf4j</groupId>
 		  <artifactId>slf4j-api</artifactId>

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/data/codec/RevisionDecoder.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/data/codec/RevisionDecoder.java
@@ -21,10 +21,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.util.Base64;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
-
-import org.apache.commons.codec.binary.Base64;
 
 import org.dkpro.jwpl.revisionmachine.common.exceptions.ConfigurationException;
 import org.dkpro.jwpl.revisionmachine.common.exceptions.DecodingException;
@@ -499,8 +498,7 @@ public class RevisionDecoder
 	 *             if an error occurs while reading the stream
 	 */
 	public void setInput(final InputStream input, final boolean binary)
-		throws IOException
-	{
+		throws IOException {
 
 		if (!binary) {
 
@@ -518,12 +516,14 @@ public class RevisionDecoder
 				v = input.read();
 			}
 
+			Base64.Decoder decoder = Base64.getDecoder();
+
 			if (zipFlag) {
 				r = new BitReader(inflateInput(
-						Base64.decodeBase64(buffer.toString()), 0));
+								decoder.decode(buffer.toString()), 0));
 			}
 			else {
-				r = new BitReader(Base64.decodeBase64(buffer.toString()));
+				r = new BitReader(decoder.decode(buffer.toString()));
 			}
 		}
 		else {
@@ -570,17 +570,16 @@ public class RevisionDecoder
 	 * @throws DecodingException
 	 *             if the decoding fails
 	 */
-	public void setInput(final String input)
-		throws DecodingException
-	{
+	public void setInput(final String input) throws DecodingException {
 
 		boolean zipFlag = input.charAt(0) == '_';
+		Base64.Decoder decoder = Base64.getDecoder();
 		if (zipFlag) {
 			r = new BitReader(inflateInput(
-					Base64.decodeBase64(input.substring(1)), 0));
+							decoder.decode(input.substring(1)), 0));
 		}
 		else {
-			byte[] data = Base64.decodeBase64(input);
+			byte[] data = decoder.decode(input);
 			if (data == null) {
 
 				for (int i = 0; i < input.length(); i++) {

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/data/codec/RevisionEncoder.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/data/codec/RevisionEncoder.java
@@ -19,10 +19,9 @@ package org.dkpro.jwpl.revisionmachine.difftool.data.codec;
 
 import java.io.ByteArrayOutputStream;
 import java.io.UnsupportedEncodingException;
+import java.util.Base64;
 import java.util.Iterator;
 import java.util.zip.Deflater;
-
-import org.apache.commons.codec.binary.Base64;
 
 import org.dkpro.jwpl.revisionmachine.common.exceptions.ConfigurationException;
 import org.dkpro.jwpl.revisionmachine.common.exceptions.EncodingException;
@@ -33,9 +32,6 @@ import org.dkpro.jwpl.revisionmachine.difftool.data.tasks.content.DiffPart;
 
 /**
  * The RevisionApi class contains methods to encode the diff information.
- *
- *
- *
  */
 public class RevisionEncoder
 	implements RevisionEncoderInterface
@@ -278,11 +274,11 @@ public class RevisionEncoder
 	 */
 	@Override
 	public String encodeDiff(final RevisionCodecData codecData, final Diff diff)
-		throws UnsupportedEncodingException, EncodingException
-	{
+		throws UnsupportedEncodingException, EncodingException {
 
 		String sEncoding;
 		byte[] bData = encode(codecData, diff);
+		Base64.Encoder encoder = Base64.getEncoder();
 		if (MODE_ZIP_COMPRESSION) {
 
 			Deflater compresser = new Deflater();
@@ -302,14 +298,14 @@ public class RevisionEncoder
 			output = stream.toByteArray();
 
 			if (bData.length + 1 < output.length) {
-				sEncoding = Base64.encodeBase64String(bData);
+				sEncoding = encoder.encodeToString(bData);
 			}
 			else {
-				sEncoding = "_" + Base64.encodeBase64String(output);
+				sEncoding = "_" + encoder.encodeToString(output);
 			}
 		}
 		else {
-			sEncoding = Base64.encodeBase64String(bData);
+			sEncoding = encoder.encodeToString(bData);
 		}
 
 		return sEncoding;


### PR DESCRIPTION
- switches to `java.util.Base64` instead of `org.apache.commons.codec.binary.Base64`
- removes (hard) dependency commons-codec from `dkpro-jwpl-revisionmachine`