### PR TITLE
#241 Update dependency Spring to version 6.x

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        java: [ 11, 17, 21 ]
+        java: [ 17, 21 ]
         experimental: [false]
 
     steps:

--- a/dkpro-jwpl-wikimachine/pom.xml
+++ b/dkpro-jwpl-wikimachine/pom.xml
@@ -35,6 +35,10 @@
             <artifactId>spring-beans</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.dkpro.jwpl</groupId>
             <artifactId>dkpro-jwpl-mwdumper</artifactId>
         </dependency>

--- a/dkpro-jwpl-wikimachine/src/main/java/org/dkpro/jwpl/wikimachine/factory/SpringFactory.java
+++ b/dkpro-jwpl-wikimachine/src/main/java/org/dkpro/jwpl/wikimachine/factory/SpringFactory.java
@@ -20,10 +20,9 @@ package org.dkpro.jwpl.wikimachine.factory;
 import java.io.File;
 
 import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.xml.XmlBeanFactory;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.FileSystemResource;
-import org.springframework.core.io.Resource;
+import org.springframework.context.support.AbstractXmlApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.context.support.FileSystemXmlApplicationContext;
 
 import org.dkpro.jwpl.wikimachine.debug.ILogger;
 import org.dkpro.jwpl.wikimachine.decompression.IDecompressor;
@@ -67,19 +66,26 @@ public class SpringFactory implements IEnvironmentFactory {
     File outerContextFile = new File(OUTER_APPLICATION_CONTEXT);
     boolean outerContextFileProper = outerContextFile.exists()
             && outerContextFile.isFile() && outerContextFile.canRead();
-    Resource res = (outerContextFileProper) ? new FileSystemResource(outerContextFile) :
-            new ClassPathResource(INNER_APPLICATION_CONTEXT);
-    return new XmlBeanFactory(res);
+
+    AbstractXmlApplicationContext ctx;
+    if (outerContextFileProper) {
+      ctx = new FileSystemXmlApplicationContext(OUTER_APPLICATION_CONTEXT);
+    } else {
+      ctx = new ClassPathXmlApplicationContext(INNER_APPLICATION_CONTEXT);
+    }
+    return ctx;
   }
 
   public static SpringFactory getInstance() {
     return instance;
   }
 
+  @Override
   public ILogger getLogger() {
     return (ILogger) factory.getBean(LOG_BEAN);
   }
 
+  @Override
   public IDecompressor getDecompressor() {
     return (IDecompressor) factory.getBean(DECOMPRESSOR_BEAN);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -32,12 +32,15 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.release>17</maven.compiler.release>
     <ukp.wikipedia.version>2.0.0-SNAPSHOT</ukp.wikipedia.version>
     <fau.ptk.version>3.0.8</fau.ptk.version>
     <fau.utils.version>3.0.8</fau.utils.version>
     <org.sweble.wikitext.version>3.1.9</org.sweble.wikitext.version>
 
-    <spring.version>5.3.30</spring.version>
+    <spring.version>6.0.13</spring.version>
     <commons.lang3.version>3.13.0</commons.lang3.version>
 
     <!-- DB specific dependency versions -->
@@ -163,6 +166,11 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-beans</artifactId>
+        <version>${spring.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-context</artifactId>
         <version>${spring.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
- sets the compiler level to `17` to comply with Spring 6.x requirements
- updates Spring dependencies to version 6.0.13
- adds necessary references to `spring-context` in wikimachine pom.xml
- removes reference to `XmlBeanFactory` in `SpringFactory` as this interface was long-time deprecated and removed in Spring 6.x