### PR TITLE
Adds empty javadoc jar to maven shade artifact in order to meet OSS Sonatype requirements

### DIFF
--- a/dkpro-jwpl-deps/dkpro-jwpl-swc-engine-shade/pom.xml
+++ b/dkpro-jwpl-deps/dkpro-jwpl-swc-engine-shade/pom.xml
@@ -78,6 +78,23 @@
 
   <build>
     <plugins>
+      <!-- This creates an empty javadoc file as required by OSS Sonatype -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>empty-javadoc-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>javadoc</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>


### PR DESCRIPTION
**What's in the PR**
* This is required to meet OSS Sonatype requirements.
* The shade doesn't need to have javadoc.

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
