### PR TITLE
Update Hibernate to 6.6.34

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <commons.logging.version>1.3.5</commons.logging.version>
 
     <!-- DB specific dependency versions -->
-    <hibernate.version>6.6.22.Final</hibernate.version>
+    <hibernate.version>6.6.34.Final</hibernate.version>
     <mysql.version>8.0.30</mysql.version>
     <mariadb.version>3.5.6</mariadb.version>
     <postgresql.version>42.6.0</postgresql.version>


### PR DESCRIPTION
**What's in the PR**
* Updates Hibernate to 6.6.34, see changelogs (incl. 6.6.23 to 6.6.34):
  - https://github.com/hibernate/hibernate-orm/blob/6.6.34/changelog.txt

**How to test manually**
* `mvn clean verify`

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
