### PR TITLE
Drop orphaned dependency on commons-logging

### DIFF
--- a/dkpro-jwpl-parser/pom.xml
+++ b/dkpro-jwpl-parser/pom.xml
@@ -38,10 +38,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/dkpro-jwpl-util/pom.xml
+++ b/dkpro-jwpl-util/pom.xml
@@ -67,10 +67,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-    </dependency>
   </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,8 @@
     <maven.compiler.target>17</maven.compiler.target>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.release>17</maven.compiler.release>
-    
+
+    <fastutil.version>8.5.18</fastutil.version>
     <fau.ptk.version>3.0.8</fau.ptk.version>
     <fau.utils.version>3.0.8</fau.utils.version>
     <org.sweble.wikitext.version>4.0.1</org.sweble.wikitext.version>
@@ -234,14 +235,9 @@
         <version>${commons.lang3.version}</version>
       </dependency>
       <dependency>
-        <groupId>commons-logging</groupId>
-        <artifactId>commons-logging</artifactId>
-        <version>${commons.logging.version}</version>
-      </dependency>
-      <dependency>
         <groupId>it.unimi.dsi</groupId>
         <artifactId>fastutil-core</artifactId>
-        <version>8.5.18</version>
+        <version>${fastutil.version}</version>
       </dependency>
       <dependency>
         <groupId>io.github.rzo1.org.sweble.wikitext</groupId>


### PR DESCRIPTION
**What's in the PR**
- removes dependency towards commons-logging
- extracts version property for fastutil-core

**How to test manually**
* `mvn clean verify`

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
