### PR TITLE
Clean up deprecated Hibernate locking calls

### DIFF
--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Page.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Page.java
@@ -281,7 +281,7 @@ public class Page
     {
         Session session = this.wiki.__getHibernateSession();
         session.beginTransaction();
-        session.buildLockRequest(LockOptions.NONE).lock(hibernatePage);
+        session.lock(hibernatePage, LockOptions.NONE);
         Set<Integer> tmp = new UnmodifiableArraySet<>(hibernatePage.getCategories());
         session.getTransaction().commit();
 
@@ -330,7 +330,7 @@ public class Page
     {
         Session session = wiki.__getHibernateSession();
         session.beginTransaction();
-        session.buildLockRequest(LockOptions.NONE).lock(hibernatePage);
+        session.lock(hibernatePage, LockOptions.NONE);
         // Have to copy links here since getPage later will close the session.
         Set<Integer> pageIDs = new UnmodifiableArraySet<>(hibernatePage.getInLinks());
         session.getTransaction().commit();
@@ -383,7 +383,7 @@ public class Page
     {
         Session session = wiki.__getHibernateSession();
         session.beginTransaction();
-        session.buildLockRequest(LockOptions.NONE).lock(hibernatePage);
+        session.lock(hibernatePage, LockOptions.NONE);
 
         Set<Integer> tmpSet = new HashSet<>(hibernatePage.getInLinks());
 
@@ -404,7 +404,7 @@ public class Page
         Session session = wiki.__getHibernateSession();
         session.beginTransaction();
         // session.lock(hibernatePage, LockMode.NONE);
-        session.buildLockRequest(LockOptions.NONE).lock(hibernatePage);
+        session.lock(hibernatePage, LockOptions.NONE);
         // Have to copy links here since getPage later will close the session.
         Set<Integer> tmpSet = new UnmodifiableArraySet<>(hibernatePage.getOutLinks());
         session.getTransaction().commit();
@@ -457,7 +457,7 @@ public class Page
 
         Session session = wiki.__getHibernateSession();
         session.beginTransaction();
-        session.buildLockRequest(LockOptions.NONE).lock(hibernatePage);
+        session.lock(hibernatePage, LockOptions.NONE);
 
         Set<Integer> tmpSet = new HashSet<>(hibernatePage.getOutLinks());
 
@@ -486,7 +486,7 @@ public class Page
     {
         Session session = wiki.__getHibernateSession();
         session.beginTransaction();
-        session.buildLockRequest(LockOptions.NONE).lock(hibernatePage);
+        session.lock(hibernatePage, LockOptions.NONE);
         Set<String> tmpSet = new HashSet<>(hibernatePage.getRedirects());
         session.getTransaction().commit();
         return tmpSet;

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Wikipedia.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Wikipedia.java
@@ -36,7 +36,6 @@ import org.dkpro.jwpl.api.exception.WikiTitleParsingException;
 import org.dkpro.jwpl.api.hibernate.WikiHibernateUtil;
 import org.dkpro.jwpl.api.util.distance.LevenshteinStringDistance;
 import org.hibernate.Session;
-import org.hibernate.query.NativeQuery;
 import org.hibernate.type.StandardBasicTypes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -690,7 +689,7 @@ public class Wikipedia
 
             // Eclipse somehow thinks that setParameter returns a MutationQuery instead of a
             // NativeQuery...
-            var nativeQuery = (NativeQuery) session.createNativeQuery(query) //
+            var nativeQuery = session.createNativeQuery(query, Long.class)
                     .setParameter("pName", encodedTitle, StandardBasicTypes.STRING);
             var returnValue = nativeQuery.uniqueResult();
             return returnValue != null;

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/hibernate/GenericDAO.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/hibernate/GenericDAO.java
@@ -136,7 +136,7 @@ public abstract class GenericDAO<T>
     public void attachClean(T instance)
     {
         try {
-            getSession().buildLockRequest(LockOptions.NONE).lock(instance);
+            getSession().lock(instance, LockOptions.NONE);
             logger.trace("attach successful");
         }
         catch (RuntimeException re) {


### PR DESCRIPTION
**What's in the PR**
 - adjusts lock calls according o Hibernate's API doc
- modernizes call with native query along the path

**How to test manually**
* `mvn clean verify`

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation

Closes #403 
