### PR TITLE
#201: Fix The cumulative size of the entity is "50,000,001"

### DIFF
--- a/dkpro-jwpl-datamachine/src/main/java/org/dkpro/jwpl/datamachine/domain/JWPLDataMachine.java
+++ b/dkpro-jwpl-datamachine/src/main/java/org/dkpro/jwpl/datamachine/domain/JWPLDataMachine.java
@@ -52,7 +52,6 @@ public class JWPLDataMachine
     private static final ILogger logger;
 
     static {
-        System.setProperty(PROP_ENTITY_SIZE_LIMIT, "0"); // compensates for #201
         Optional<IEnvironmentFactory> candidate = ServiceLoader.load(IEnvironmentFactory.class).findFirst();
         environmentFactory = candidate.orElseThrow(
                 () -> new RuntimeException("Error detecting required runtime environment components! " +
@@ -66,6 +65,7 @@ public class JWPLDataMachine
     public static void main(String[] args)
     {
         if (args.length > 3) {
+            System.setProperty(PROP_ENTITY_SIZE_LIMIT, "0"); // compensates for #201
             Configuration config = getConfigFromArgs(args);
             DataMachineFiles files = new DataMachineFiles(logger);
             files.setDataDirectory(args[DATADIR_ARG]);

--- a/dkpro-jwpl-timemachine/src/main/java/org/dkpro/jwpl/timemachine/domain/JWPLTimeMachine.java
+++ b/dkpro-jwpl-timemachine/src/main/java/org/dkpro/jwpl/timemachine/domain/JWPLTimeMachine.java
@@ -38,7 +38,6 @@ public class JWPLTimeMachine
     private static final ILogger logger;
 
     static {
-        System.setProperty(PROP_ENTITY_SIZE_LIMIT, "0"); // compensates for #201
         Optional<IEnvironmentFactory> candidate = ServiceLoader.load(IEnvironmentFactory.class).findFirst();
         environmentFactory = candidate.orElseThrow(
                 () -> new RuntimeException("Error detecting required runtime environment components! " +
@@ -66,9 +65,9 @@ public class JWPLTimeMachine
 
     public static void main(String[] args)
     {
-
         try {
             if (checkArgs(args)) {
+                System.setProperty(PROP_ENTITY_SIZE_LIMIT, "0"); // compensates for #201
                 logger.log("parsing configuration file....");
                 Configuration config = SettingsXML.loadConfiguration(args[0], logger);
                 TimeMachineFiles files = SettingsXML.loadFiles(args[0], logger);


### PR DESCRIPTION
**What's in the PR**
- sets`jdk.xml.totalEntitySizeLimit` to "0" on cli startup of DataMachine and TimeMachine
- closes #201

**How to test manually**
* `mvn clean verify`

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
