### PR TITLE
Update Hibernate to 6.6.40

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <xz.version>1.11</xz.version>
     
     <!-- DB specific dependency versions -->
-    <hibernate.version>6.6.34.Final</hibernate.version>
+    <hibernate.version>6.6.40.Final</hibernate.version>
     <mysql.version>8.0.30</mysql.version>
     <mariadb.version>3.5.7</mariadb.version>
     <postgresql.version>42.6.0</postgresql.version>


### PR DESCRIPTION
**What's in the PR**
- Updates Hibernate to 6.6.40, see changelogs (incl. 6.6.35 to 6.6.40):
  - https://github.com/hibernate/hibernate-orm/blob/6.6.40/changelog.txt

**How to test manually**
* `mvn clean verify`

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
