### PR TITLE
New version of nv-i18n with recent changes to codes

### DIFF
--- a/dkpro-jwpl-api/pom.xml
+++ b/dkpro-jwpl-api/pom.xml
@@ -62,7 +62,7 @@
       <artifactId>swc-engine</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.neovisionaries</groupId>
+      <groupId>uk.co.foundationsedge</groupId>
       <artifactId>nv-i18n</artifactId>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -205,9 +205,9 @@
         <version>1.5.3</version>
       </dependency>
       <dependency>
-        <groupId>com.neovisionaries</groupId>
+        <groupId>uk.co.foundationsedge</groupId>
         <artifactId>nv-i18n</artifactId>
-        <version>1.29</version>
+        <version>1.33</version>
       </dependency>
       <dependency>
         <groupId>mysql</groupId>


### PR DESCRIPTION
Update nv-18n to new group which is under active development.

The original nv-i18n library is no longer used. As we require recent changes in our organisation we have forked and intend to maintain this as it's business critical to us.

