### PR TITLE
fix(test): make the e2e harnesses idempotent across repeated verify runs (#493)

### DIFF
--- a/dkpro-jwpl-datamachine/src/test-e2e/java/org/dkpro/jwpl/datamachine/domain/JWPLDataMachineE2ETest.java
+++ b/dkpro-jwpl-datamachine/src/test-e2e/java/org/dkpro/jwpl/datamachine/domain/JWPLDataMachineE2ETest.java
@@ -28,6 +28,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -129,18 +130,21 @@ public class JWPLDataMachineE2ETest {
   @BeforeAll
   public static void initEnv() throws IOException {
     Files.createDirectories(Path.of(OUTPUT_DIR));
-    Stream<Path> results = Files.find(Path.of(BASE.getFile()), Integer.MAX_VALUE,
+    // Copy (do not move) the fixtures: keeping the originals in place makes repeated
+    // invocations of 'mvn verify' over a populated 'target' directory idempotent.
+    try (Stream<Path> results = Files.find(Path.of(BASE.getFile()), Integer.MAX_VALUE,
             (path, basicFileAttributes)
                     -> path.toFile().getName().startsWith(WIKI_NAME)
-    );
-
-    results.forEach(p -> {
-      try {
-        Files.move(p, Path.of(OUTPUT_DIR, p.getFileName().toString()));
-      } catch (IOException e) {
-        throw new UncheckedIOException(e);
-      }
-    });
+    )) {
+      results.forEach(p -> {
+        try {
+          Files.copy(p, Path.of(OUTPUT_DIR, p.getFileName().toString()),
+                  StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+          throw new UncheckedIOException(e);
+        }
+      });
+    }
   }
 
   @BeforeEach

--- a/dkpro-jwpl-revisionmachine/src/test-e2e/java/org/dkpro/jwpl/revisionmachine/difftool/DiffToolE2ETest.java
+++ b/dkpro-jwpl-revisionmachine/src/test-e2e/java/org/dkpro/jwpl/revisionmachine/difftool/DiffToolE2ETest.java
@@ -25,6 +25,7 @@ import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -61,18 +62,21 @@ public class DiffToolE2ETest {
   public static void initEnv() throws IOException {
     Files.createDirectories(Path.of(OUTPUT_DIR));
     Files.createDirectories(Path.of(LOGS_DIR));
-    Stream<Path> results = Files.find(Path.of(BASE.getFile()), Integer.MAX_VALUE,
+    // Copy (do not move) the fixtures: keeping the originals in place makes repeated
+    // invocations of 'mvn verify' over a populated 'target' directory idempotent.
+    try (Stream<Path> results = Files.find(Path.of(BASE.getFile()), Integer.MAX_VALUE,
             (path, basicFileAttributes)
                     -> path.toFile().getName().startsWith(WIKI_NAME)
-    );
-
-    results.forEach(p -> {
-      try {
-        Files.move(p, Path.of(OUTPUT_DIR, p.getFileName().toString()));
-      } catch (IOException e) {
-        throw new UncheckedIOException(e);
-      }
-    });
+    )) {
+      results.forEach(p -> {
+        try {
+          Files.copy(p, Path.of(OUTPUT_DIR, p.getFileName().toString()),
+                  StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+          throw new UncheckedIOException(e);
+        }
+      });
+    }
   }
 
   @BeforeEach

--- a/dkpro-jwpl-timemachine/src/test-e2e/java/org/dkpro/jwpl/timemachine/domain/JWPLTimeMachineE2ETest.java
+++ b/dkpro-jwpl-timemachine/src/test-e2e/java/org/dkpro/jwpl/timemachine/domain/JWPLTimeMachineE2ETest.java
@@ -28,6 +28,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -132,18 +133,21 @@ public class JWPLTimeMachineE2ETest {
   public static void initEnv() throws IOException {
     Files.createDirectories(Path.of(EXEC_DIR));
     Files.createDirectories(Path.of(OUTPUT_DIR));
-    Stream<Path> results = Files.find(Path.of(BASE.getFile()), Integer.MAX_VALUE,
+    // Copy (do not move) the fixtures: keeping the originals in place makes repeated
+    // invocations of 'mvn verify' over a populated 'target' directory idempotent.
+    try (Stream<Path> results = Files.find(Path.of(BASE.getFile()), Integer.MAX_VALUE,
             (path, basicFileAttributes)
                     -> path.toFile().getName().startsWith(WIKI_NAME)
-    );
-
-    results.forEach(p -> {
-      try {
-        Files.move(p, Path.of(EXEC_DIR, p.getFileName().toString()));
-      } catch (IOException e) {
-        throw new UncheckedIOException(e);
-      }
-    });
+    )) {
+      results.forEach(p -> {
+        try {
+          Files.copy(p, Path.of(EXEC_DIR, p.getFileName().toString()),
+                  StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+          throw new UncheckedIOException(e);
+        }
+      });
+    }
   }
 
   @BeforeEach


### PR DESCRIPTION
Fixes #493.

The three e2e harnesses moved their fixtures out of the classpath directory into the tool execution directory. A second `mvn verify` over a populated `target/` found the destination already present and failed with `FileAlreadyExistsException`, so `-Ptest-e2e-tools` worked only once per `clean`. CI never saw this because it always builds a fresh checkout.

`Files.move` is replaced by `Files.copy` with `REPLACE_EXISTING`. Copying is idempotent and, unlike the move, does not remove the fixture from the output of an earlier build phase. Nothing downstream depends on the source being gone: the only directory scan in the affected production paths is the non-recursive `listFiles` in `DataMachineFiles`, rooted at the data directory passed explicitly as an argument, and the timemachine and revisionmachine runs are driven entirely by config files naming each input by path.

The `Files.find` streams are closed via try-with-resources, in `initEnv` and in the two test methods that opened a second stream.

Verified by three consecutive `verify` runs without an intervening `clean`, all three harnesses executing 2/2 in each.