### PR TITLE
fix(api): key the session-factory cache on all connection-affecting values (#494)

### DIFF
--- a/dkpro-jwpl-api/README.md
+++ b/dkpro-jwpl-api/README.md
@@ -61,9 +61,11 @@ dbConfig.setHibernateProperties(hibernateProperties);
 Wikipedia wiki = new Wikipedia(dbConfig);
 ```
 
-Populate the settings **before** the first `new Wikipedia(config)` for a given
-language/host/database combination: session factories are cached JVM-wide and built only once per
-combination.
+Populate the settings **before** the first `new Wikipedia(config)` for a given database
+configuration: session factories are cached JVM-wide and built only once per configuration. The
+cache key is derived from the connection-affecting values -- language, host, database, JDBC url,
+driver, user and password -- so two configurations differing in any of them get their own factory.
+The Hibernate settings bag above is deliberately *not* part of that key.
 
 ## Persistence
 

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/hibernate/WikiHibernateUtil.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/hibernate/WikiHibernateUtil.java
@@ -18,14 +18,18 @@
 package org.dkpro.jwpl.api.hibernate;
 
 import java.lang.invoke.MethodHandles;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.HashMap;
+import java.util.HexFormat;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.dkpro.jwpl.api.DatabaseConfiguration;
 import org.dkpro.jwpl.api.WikiConstants;
@@ -59,14 +63,95 @@ public class WikiHibernateUtil
     private static final String ADD_VERSION_COLUMN_DDL = "ALTER TABLE MetaData ADD COLUMN version "
             + "VARCHAR(255) DEFAULT NULL;";
 
-    private static final Map<String, SessionFactory> sessionFactoryMap = new HashMap<>();
+    /**
+     * The JVM-wide session factory cache. Both the {@link SessionFactory} and the {@code MetaData}
+     * entity probed for it live in a single {@link CachedSessionFactory} value, so that the two can
+     * not drift apart.
+     */
+    private static final Map<SessionFactoryKey, CachedSessionFactory> sessionFactoryMap
+            = new ConcurrentHashMap<>();
 
     /**
-     * The {@code MetaData} entity bound for a given session factory, keyed exactly like
-     * {@link #sessionFactoryMap} so that both stay in lockstep.
+     * The immutable, value derived cache key of a {@link DatabaseConfiguration}. Every field which
+     * affects the connection a {@link SessionFactory} ends up using is a component here, so that two
+     * configurations differing in any of them cannot share a cached factory. Being a record, equality
+     * is component wise - unlike a concatenated string it therefore cannot suffer boundary collisions
+     * such as {@code host="hostdb", database="x"} versus {@code host="host", database="dbx"}.
+     * <p>
+     * The password is held as a digest only, never in the clear.
+     *
+     * @param language        The wiki {@link Language}; {@code null} is tolerated by the key itself.
+     * @param host            The database host.
+     * @param database        The database name.
+     * @param jdbcURL         The JDBC url the connection is actually opened against.
+     * @param databaseDriver  The JDBC driver class name; may be {@code null}.
+     * @param user            The database user; may be {@code null}.
+     * @param passwordDigest  The SHA-256 hex digest of the password, or {@code null} if the password
+     *                        itself was {@code null}.
      */
-    private static final Map<String, Class<? extends AbstractMetaData>> metaDataEntityMap
-            = new HashMap<>();
+    record SessionFactoryKey(Language language, String host, String database, String jdbcURL,
+            String databaseDriver, String user, String passwordDigest)
+    {
+
+        /**
+         * Renders every component but the password, which is elided entirely - not even its digest is
+         * shown. The generated record {@code toString()} would print all components, and this
+         * representation is what can end up in a log statement or an exception message.
+         */
+        @Override
+        public String toString()
+        {
+            return "SessionFactoryKey[language=" + language + ", host=" + host + ", database="
+                    + database + ", jdbcURL=" + jdbcURL + ", databaseDriver=" + databaseDriver
+                    + ", user=" + user + ", password=***]";
+        }
+    }
+
+    /**
+     * A lazily built cache entry pairing a {@link SessionFactory} with the {@code MetaData} entity
+     * that was bound into it. Keeping both in one value makes the lockstep of the two structural
+     * rather than a convention.
+     * <p>
+     * The entry object itself is cheap to create, which is what allows it to be installed via
+     * {@link ConcurrentHashMap#computeIfAbsent(Object, java.util.function.Function)}: the expensive
+     * schema probe and the Hibernate bootstrap happen afterwards, under this entry's own lock, and so
+     * neither block unrelated keys nor re-enter the map from within a mapping function.
+     */
+    private static final class CachedSessionFactory
+    {
+
+        private volatile SessionFactory sessionFactory;
+
+        private volatile Class<? extends AbstractMetaData> metaDataEntity;
+
+        /**
+         * Builds the {@link SessionFactory} and probes the bound entity, exactly once. A failed
+         * attempt leaves this entry uninitialized, so that a later call may retry.
+         *
+         * @param config The {@link DatabaseConfiguration} this entry was keyed for.
+         */
+        private void initialize(DatabaseConfiguration config)
+        {
+            if (sessionFactory != null) {
+                return;
+            }
+            synchronized (this) {
+                if (sessionFactory != null) {
+                    return;
+                }
+                Class<? extends AbstractMetaData> entity = hasMetaDataVersionColumn(config)
+                        ? MetaData.class
+                        : LegacyMetaData.class;
+                Configuration configuration = getConfiguration(config, entity);
+                StandardServiceRegistryBuilder ssrb = new StandardServiceRegistryBuilder()
+                        .applySettings(configuration.getProperties());
+                SessionFactory built = configuration.buildSessionFactory(ssrb.build());
+                metaDataEntity = entity;
+                // Published last: a non-null 'sessionFactory' signals that both fields are set.
+                sessionFactory = built;
+            }
+        }
+    }
 
     /**
      * Retrieves (and creates) a {@link SessionFactory} for a specified {@link DatabaseConfiguration}.
@@ -78,39 +163,7 @@ public class WikiHibernateUtil
      */
     public static SessionFactory getSessionFactory(DatabaseConfiguration config)
     {
-
-        if (config.getLanguage() == null) {
-            throw new ExceptionInInitializerError(
-                    "Database configuration error. 'Language' is empty.");
-        }
-        else if (config.getHost() == null) {
-            throw new ExceptionInInitializerError("Database configuration error. 'Host' is empty.");
-        }
-        else if (config.getDatabase() == null) {
-            throw new ExceptionInInitializerError(
-                    "Database configuration error. 'Database' is empty.");
-        }
-        else if (config.getJdbcURL() == null) {
-            throw new ExceptionInInitializerError(
-                    "Database configuration error. 'JdbcURL' is empty.");
-        }
-
-        // Note: the key intentionally ignores the JDBC URL, the driver and the credentials.
-        // It now also binds the probed 'MetaData' entity choice - see metaDataEntityMap.
-        String uniqueSessionKey = config.getLanguage().toString() + config.getHost()
-                + config.getDatabase();
-        if (!sessionFactoryMap.containsKey(uniqueSessionKey)) {
-            Class<? extends AbstractMetaData> metaDataEntity = hasMetaDataVersionColumn(config)
-                    ? MetaData.class
-                    : LegacyMetaData.class;
-            Configuration configuration = getConfiguration(config, metaDataEntity);
-            StandardServiceRegistryBuilder ssrb = new StandardServiceRegistryBuilder()
-                    .applySettings(configuration.getProperties());
-            SessionFactory sessionFactory = configuration.buildSessionFactory(ssrb.build());
-            sessionFactoryMap.put(uniqueSessionKey, sessionFactory);
-            metaDataEntityMap.put(uniqueSessionKey, metaDataEntity);
-        }
-        return sessionFactoryMap.get(uniqueSessionKey);
+        return cacheEntry(config).sessionFactory;
     }
 
     /**
@@ -128,11 +181,95 @@ public class WikiHibernateUtil
     public static Class<? extends AbstractMetaData> getMetaDataEntityClass(
             DatabaseConfiguration config)
     {
-        // Ensures the probe has run and the map is populated; idempotent and cached.
-        getSessionFactory(config);
-        String uniqueSessionKey = config.getLanguage().toString() + config.getHost()
-                + config.getDatabase();
-        return metaDataEntityMap.getOrDefault(uniqueSessionKey, MetaData.class);
+        return cacheEntry(config).metaDataEntity;
+    }
+
+    /**
+     * Looks up - building it if required - the cache entry for a specified
+     * {@link DatabaseConfiguration}.
+     *
+     * @param config The {@link DatabaseConfiguration} to obtain the entry for.
+     * @return A fully initialized {@link CachedSessionFactory}.
+     * 
+     * @throws ExceptionInInitializerError Thrown if the {@code config} instance was incorrect or incomplete.
+     */
+    private static CachedSessionFactory cacheEntry(DatabaseConfiguration config)
+    {
+        validate(config);
+        CachedSessionFactory entry = sessionFactoryMap.computeIfAbsent(keyOf(config),
+                key -> new CachedSessionFactory());
+        entry.initialize(config);
+        return entry;
+    }
+
+    /**
+     * Derives the cache key of a specified {@link DatabaseConfiguration}. This is the single place
+     * where the key is built, so a connection affecting field added later needs to be picked up here
+     * only.
+     * <p>
+     * The values are snapshotted rather than the configuration being used as the key itself:
+     * {@link DatabaseConfiguration} is public, mutable and subclassed, and callers hold on to the very
+     * instance they handed to JWPL. A configuration mutated after first use therefore simply maps to
+     * a different key - and, mutated back, to the original entry again.
+     *
+     * @param config The {@link DatabaseConfiguration} to derive a key for.
+     * @return The derived {@link SessionFactoryKey}.
+     */
+    static SessionFactoryKey keyOf(DatabaseConfiguration config)
+    {
+        return new SessionFactoryKey(config.getLanguage(), config.getHost(), config.getDatabase(),
+                config.getJdbcURL(), config.getDatabaseDriver(), config.getUser(),
+                digest(config.getPassword()));
+    }
+
+    /**
+     * Digests a password so that it can take part in the cache key without being retained in the
+     * clear.
+     *
+     * @param password The password to digest; may be {@code null}.
+     * @return The SHA-256 hex digest, or {@code null} for a {@code null} password - which keeps
+     *         {@code null} and {@code ""} distinguishable.
+     */
+    private static String digest(String password)
+    {
+        if (password == null) {
+            return null;
+        }
+        try {
+            MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of()
+                    .formatHex(sha256.digest(password.getBytes(StandardCharsets.UTF_8)));
+        }
+        catch (NoSuchAlgorithmException e) {
+            // Every JDK is required to provide SHA-256, so this is unreachable in practice.
+            throw new IllegalStateException("SHA-256 is not available in this JVM.", e);
+        }
+    }
+
+    /**
+     * Rejects a {@link DatabaseConfiguration} which lacks a value required to open a connection.
+     *
+     * @param config The {@link DatabaseConfiguration} to check.
+     * 
+     * @throws ExceptionInInitializerError Thrown if the {@code config} instance was incorrect or incomplete.
+     */
+    private static void validate(DatabaseConfiguration config)
+    {
+        if (config.getLanguage() == null) {
+            throw new ExceptionInInitializerError(
+                    "Database configuration error. 'Language' is empty.");
+        }
+        else if (config.getHost() == null) {
+            throw new ExceptionInInitializerError("Database configuration error. 'Host' is empty.");
+        }
+        else if (config.getDatabase() == null) {
+            throw new ExceptionInInitializerError(
+                    "Database configuration error. 'Database' is empty.");
+        }
+        else if (config.getJdbcURL() == null) {
+            throw new ExceptionInInitializerError(
+                    "Database configuration error. 'JdbcURL' is empty.");
+        }
     }
 
     /**

--- a/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/LegacyMetaDataTest.java
+++ b/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/LegacyMetaDataTest.java
@@ -44,8 +44,9 @@ public class LegacyMetaDataTest
     private static final String LEGACY_URL = "jdbc:hsqldb:mem:wikiapi_legacy";
     private static final String LEGACY_DB = "wikiapi_legacy";
     /*
-     * Note well: session factories are cached JVM-wide under language + host + database, so every
-     * configuration below uses a distinct database name to force a fresh probe.
+     * Note well: session factories are cached JVM-wide, keyed by the connection affecting values of
+     * a configuration - the caller supplied Hibernate settings are deliberately not among them. So
+     * every configuration below uses a distinct database name to force a fresh probe.
      */
     private static final String VALIDATE_DB = "wikiapi_legacy_validate";
     private static final String SHOW_SQL_DB = "wikiapi_legacy_showsql";

--- a/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/hibernate/SessionFactoryCacheTest.java
+++ b/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/hibernate/SessionFactoryCacheTest.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.jwpl.api.hibernate;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.dkpro.jwpl.api.DatabaseConfiguration;
+import org.dkpro.jwpl.api.WikiConstants.Language;
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that the JVM-wide session factory cache honours the derived key: configurations carrying
+ * equal values share one {@link SessionFactory}, configurations differing in a connection-affecting
+ * field do not, and concurrent first-time access builds exactly one {@link SessionFactory}.
+ * <p>
+ * Dedicated in-memory databases are used here, so that neither the shared test fixture nor its
+ * cached {@link SessionFactory} are affected. HSQLDB is deliberately hardcoded rather than taken
+ * from {@code JwplTestDatabase}: it is a test scoped dependency of every module and so is present
+ * whichever backend the surrounding suite runs against, and none of the assertions below read a
+ * single row - an empty schema is all these factories ever need.
+ */
+public class SessionFactoryCacheTest
+{
+
+    private static final String DRIVER = "org.hsqldb.jdbcDriver";
+    private static final String DB = "jwpl_cache";
+    private static final String URL = "jdbc:hsqldb:mem:" + DB;
+    /** Same logical database, reached via a second JDBC url - the very case issue #494 reports. */
+    private static final String ALTERNATE_URL = "jdbc:hsqldb:mem:jwpl_cache_alt";
+    private static final String RACE_DB = "jwpl_cache_race";
+
+    private static final String SECOND_USER = "jwpl";
+    private static final String SECOND_PASSWORD = "jwpl";
+
+    private static final int THREADS = 8;
+
+    @BeforeAll
+    public static void createSecondUser() throws SQLException
+    {
+        // A second set of credentials valid against the very same database, so that the credential
+        // dimension of the key can be exercised with two factories that both actually build.
+        try (Connection connection = DriverManager.getConnection(URL, "sa", "");
+                Statement statement = connection.createStatement()) {
+            statement.execute("CREATE USER \"" + SECOND_USER + "\" PASSWORD '" + SECOND_PASSWORD
+                    + "' ADMIN");
+        }
+    }
+
+    private static DatabaseConfiguration config()
+    {
+        return new DatabaseConfiguration(DRIVER, URL, "localhost", DB, "sa", "", Language._test);
+    }
+
+    @Test
+    public void testDistinctButEqualConfigurationsShareOneSessionFactory()
+    {
+        SessionFactory a = WikiHibernateUtil.getSessionFactory(config());
+        SessionFactory b = WikiHibernateUtil.getSessionFactory(config());
+
+        assertNotNull(a);
+        assertSame(a, b);
+    }
+
+    @Test
+    public void testDifferingJdbcUrlYieldsDistinctSessionFactories()
+    {
+        DatabaseConfiguration other = config();
+        other.setJdbcURL(ALTERNATE_URL);
+
+        assertNotSame(WikiHibernateUtil.getSessionFactory(config()),
+                WikiHibernateUtil.getSessionFactory(other));
+    }
+
+    @Test
+    public void testDifferingCredentialsYieldDistinctSessionFactories()
+    {
+        DatabaseConfiguration other = config();
+        other.setUser(SECOND_USER);
+        other.setPassword(SECOND_PASSWORD);
+
+        assertNotSame(WikiHibernateUtil.getSessionFactory(config()),
+                WikiHibernateUtil.getSessionFactory(other));
+    }
+
+    @Test
+    public void testMutatingAConfigurationBackRestoresItsOriginalSessionFactory()
+    {
+        DatabaseConfiguration config = config();
+        SessionFactory original = WikiHibernateUtil.getSessionFactory(config);
+
+        config.setJdbcURL(ALTERNATE_URL);
+        assertNotSame(original, WikiHibernateUtil.getSessionFactory(config));
+
+        config.setJdbcURL(URL);
+        assertSame(original, WikiHibernateUtil.getSessionFactory(config));
+    }
+
+    @Test
+    public void testMetaDataEntityStaysInLockstepWithItsSessionFactory()
+    {
+        DatabaseConfiguration config = config();
+
+        // The entity is resolved from the very same cache entry as the factory, so asking for it
+        // must neither return null nor build a second factory.
+        SessionFactory sessionFactory = WikiHibernateUtil.getSessionFactory(config);
+        assertSame(MetaData.class, WikiHibernateUtil.getMetaDataEntityClass(config));
+        assertSame(sessionFactory, WikiHibernateUtil.getSessionFactory(config));
+    }
+
+    @Test
+    public void testConcurrentFirstTimeAccessBuildsOneSessionFactory() throws Exception
+    {
+        CountDownLatch startSignal = new CountDownLatch(1);
+        CountDownLatch doneSignal = new CountDownLatch(THREADS);
+        List<SessionFactory> obtained = new CopyOnWriteArrayList<>();
+        List<Throwable> failures = new CopyOnWriteArrayList<>();
+
+        for (int i = 0; i < THREADS; i++) {
+            Thread t = new Thread(() -> {
+                try {
+                    startSignal.await();
+                    obtained.add(WikiHibernateUtil.getSessionFactory(raceConfig()));
+                }
+                catch (Throwable e) {
+                    failures.add(e);
+                }
+                finally {
+                    doneSignal.countDown();
+                }
+            });
+            t.setDaemon(true);
+            t.start();
+        }
+
+        startSignal.countDown();
+        assertTrue(doneSignal.await(2, TimeUnit.MINUTES), "Threads did not finish in time.");
+        assertTrue(failures.isEmpty(), "Obtaining a SessionFactory failed: " + failures);
+
+        SessionFactory expected = WikiHibernateUtil.getSessionFactory(raceConfig());
+        for (SessionFactory sessionFactory : obtained) {
+            assertSame(expected, sessionFactory);
+        }
+    }
+
+    private static DatabaseConfiguration raceConfig()
+    {
+        return new DatabaseConfiguration(DRIVER, "jdbc:hsqldb:mem:" + RACE_DB, "localhost", RACE_DB,
+                "sa", "", Language._test);
+    }
+}

--- a/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/hibernate/WikiHibernateUtilKeyTest.java
+++ b/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/hibernate/WikiHibernateUtilKeyTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.jwpl.api.hibernate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.dkpro.jwpl.api.DatabaseConfiguration;
+import org.dkpro.jwpl.api.WikiConstants.Language;
+import org.dkpro.jwpl.api.hibernate.WikiHibernateUtil.SessionFactoryKey;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the derivation of the session factory cache key. No database is required here as only the
+ * key itself is under test.
+ */
+public class WikiHibernateUtilKeyTest
+{
+
+    private static final String DRIVER = "org.hsqldb.jdbcDriver";
+    private static final String URL = "jdbc:hsqldb:mem:wikiapi_key_test";
+    private static final String SECRET = "s3cr3t-p4ssw0rd";
+
+    private static DatabaseConfiguration config()
+    {
+        return new DatabaseConfiguration(DRIVER, URL, "localhost", "wikiapi_test", "sa", SECRET,
+                Language._test);
+    }
+
+    @Test
+    public void testEqualValuesYieldEqualKeys()
+    {
+        SessionFactoryKey a = WikiHibernateUtil.keyOf(config());
+        SessionFactoryKey b = WikiHibernateUtil.keyOf(config());
+
+        assertNotNull(a);
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void testHostAndDatabaseBoundaryDoesNotCollide()
+    {
+        DatabaseConfiguration a = config();
+        a.setHost("hostdb");
+        a.setDatabase("x");
+
+        DatabaseConfiguration b = config();
+        b.setHost("host");
+        b.setDatabase("dbx");
+
+        assertNotEquals(WikiHibernateUtil.keyOf(a), WikiHibernateUtil.keyOf(b));
+    }
+
+    @Test
+    public void testDifferingJdbcUrlYieldsDifferentKey()
+    {
+        DatabaseConfiguration other = config();
+        other.setJdbcURL("jdbc:hsqldb:hsql://localhost:9001/wikiapi_test");
+
+        assertNotEquals(WikiHibernateUtil.keyOf(config()), WikiHibernateUtil.keyOf(other));
+    }
+
+    @Test
+    public void testDifferingDatabaseDriverYieldsDifferentKey()
+    {
+        DatabaseConfiguration other = config();
+        other.setDatabaseDriver("org.mariadb.jdbc.Driver");
+
+        assertNotEquals(WikiHibernateUtil.keyOf(config()), WikiHibernateUtil.keyOf(other));
+    }
+
+    @Test
+    public void testDifferingUserYieldsDifferentKey()
+    {
+        DatabaseConfiguration other = config();
+        other.setUser("someone-else");
+
+        assertNotEquals(WikiHibernateUtil.keyOf(config()), WikiHibernateUtil.keyOf(other));
+    }
+
+    @Test
+    public void testDifferingPasswordYieldsDifferentKey()
+    {
+        DatabaseConfiguration other = config();
+        other.setPassword("another-password");
+
+        assertNotEquals(WikiHibernateUtil.keyOf(config()), WikiHibernateUtil.keyOf(other));
+    }
+
+    @Test
+    public void testDifferingLanguageYieldsDifferentKey()
+    {
+        DatabaseConfiguration other = config();
+        other.setLanguage(Language.english);
+
+        assertNotEquals(WikiHibernateUtil.keyOf(config()), WikiHibernateUtil.keyOf(other));
+    }
+
+    @Test
+    public void testNullPasswordIsToleratedAndDistinctFromEmptyPassword()
+    {
+        DatabaseConfiguration nullPassword = config();
+        nullPassword.setPassword(null);
+
+        DatabaseConfiguration emptyPassword = config();
+        emptyPassword.setPassword("");
+
+        SessionFactoryKey nullKey = WikiHibernateUtil.keyOf(nullPassword);
+        assertNull(nullKey.passwordDigest());
+        assertNotEquals(nullKey, WikiHibernateUtil.keyOf(emptyPassword));
+    }
+
+    @Test
+    public void testPasswordIsNeverExposedByTheKey()
+    {
+        SessionFactoryKey key = WikiHibernateUtil.keyOf(config());
+
+        assertNotEquals(SECRET, key.passwordDigest());
+        assertFalse(key.passwordDigest().contains(SECRET));
+        assertFalse(key.toString().contains(SECRET));
+        assertFalse(key.toString().contains(key.passwordDigest()));
+    }
+}


### PR DESCRIPTION
Fixes #494.

`WikiHibernateUtil` cached session factories JVM-wide under the concatenation of language, host and database. The JDBC url, driver, user and password did not participate, so two configurations differing only in those fields shared one factory and the first constructed won — a second `Wikipedia` instance kept the first URL and credentials. The concatenation was also ambiguous, so `("en","hostdb","x")` and `("en","host","dbx")` collided.

The key is now an immutable record of every connection-affecting value, derived in a single method. Record equality is component-wise, so the boundary collision cannot occur and no separator or escaping scheme is needed.

`DatabaseConfiguration` is deliberately not used as the key, and is not modified. It is public, mutable and subclassed; `Wikipedia` retains the caller's instance by reference and hands it back from `getDatabaseConfiguration()`, and `GenericDAO` passes that same live object to `getSessionFactory`. Construct-then-mutate is the dominant idiom across the tests, tutorials and `RevisionApi`. Giving the class `equals`/`hashCode` would mean a caller mutating a setter after first use orphans its own cache entry and leaks a second factory — the same class of bug one level up. Snapshotting the values avoids it: a mutated configuration maps to a different key, and one mutated back maps to the original entry again.

The password participates only as a SHA-256 digest (`MessageDigest` + `HexFormat`, so no new dependency). The record's `toString` is overridden to omit both the password and the digest, since a record's generated `toString` is what could otherwise reach a log line or an exception message. A null password maps to a null digest, keeping null and `""` distinct.

The map is a `ConcurrentHashMap`, so concurrent first-time construction no longer races. The separate `metaDataEntityMap` introduced alongside the schema probe in #492 is folded into the same cache entry rather than kept in lockstep by convention, so a factory and its bound `MetaData` entity cannot diverge. The probe is otherwise unchanged: once per factory, every failure path still assumes the current layout, and the caller-supplied Hibernate settings are still merged last.

No public signature or observable behaviour changes. New tests cover key equality and separation on each field, the boundary collision, null vs empty password, that neither the digest nor the password is rendered, factory reuse and mutate-then-mutate-back, the factory/entity lockstep, and 8 threads racing first-time access producing exactly one factory.