### PR TITLE
fix: chain caught exceptions and stop discarding their information (#187)

### DIFF
--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/CategoryGraph.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/CategoryGraph.java
@@ -286,7 +286,7 @@ public class CategoryGraph
                     cat = new Category(this.wiki, hibernateID);
                 }
                 catch (WikiPageNotFoundException e) {
-                    throw new WikiApiException("Category not found");
+                    throw new WikiApiException("Category not found", e);
                 }
 
                 if (matchesFilter(cat, filterList)) {
@@ -318,7 +318,7 @@ public class CategoryGraph
                 cat = new Category(this.wiki, hibernateID);
             }
             catch (WikiPageNotFoundException e) {
-                throw new WikiApiException("Category not found");
+                throw new WikiApiException("Category not found", e);
             }
 
             // get parents and children

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/CategoryTitleComparator.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/CategoryTitleComparator.java
@@ -17,9 +17,12 @@
  */
 package org.dkpro.jwpl.api;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Comparator;
 
 import org.dkpro.jwpl.api.exception.WikiTitleParsingException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Compares two {@link Category categories} based on the lexicographic ordering of their titles.
@@ -27,6 +30,9 @@ import org.dkpro.jwpl.api.exception.WikiTitleParsingException;
 public class CategoryTitleComparator
     implements Comparator<Category>
 {
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public int compare(Category o1, Category o2)
@@ -37,7 +43,7 @@ public class CategoryTitleComparator
             retVal = o1.getTitle().getPlainTitle().compareTo(o2.getTitle().getPlainTitle());
         }
         catch (WikiTitleParsingException e) {
-            e.printStackTrace();
+            logger.error("Could not compare category titles.", e);
         }
         return retVal;
     }

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Page.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Page.java
@@ -247,7 +247,7 @@ public class Page
                     }
                     catch (WikiPageNotFoundException e) {
                         throw new WikiPageNotFoundException("No page with name " + DISCUSSION_PREFIX
-                                + getTitle().getRawTitleText() + " was found.");
+                                + getTitle().getRawTitleText() + " was found.", e);
                     }
                 }
             }

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/PageIterator.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/PageIterator.java
@@ -203,7 +203,7 @@ public class PageIterator
                             bufferFillSize++;
                         }
                         catch (WikiApiException e) {
-                            logger.warn("Missing article with id {}", id);
+                            logger.warn("Missing article with id {}", id, e);
                         }
                     }
                 }
@@ -215,7 +215,7 @@ public class PageIterator
                             bufferFillSize++;
                         }
                         catch (WikiApiException e) {
-                          logger.warn("Missing article with title \"{}\"", title);
+                          logger.warn("Missing article with title \"{}\"", title, e);
                         }
                     }
                 }
@@ -273,7 +273,7 @@ public class PageIterator
                             }
                         }
                         catch (WikiApiException e) {
-                            logger.error("Page with hibernateID {} not found.", id);
+                            logger.error("Page with hibernateID {} not found.", id, e);
                         }
                         lastPage = id;
                     }

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/PageQueryIterable.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/PageQueryIterable.java
@@ -111,7 +111,7 @@ public class PageQueryIterable
             }
             catch (WikiPageNotFoundException e) {
                 logger.warn("Page with pageID {} could not be found. Fatal error. Terminating.",
-                        pageID);
+                        pageID, e);
             }
 
             if (!(q.getMinIndegree() >= 0 && q.getMaxIndegree() >= 0

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/PageTitleComparator.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/PageTitleComparator.java
@@ -17,9 +17,12 @@
  */
 package org.dkpro.jwpl.api;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Comparator;
 
 import org.dkpro.jwpl.api.exception.WikiTitleParsingException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Compares two pages based on the lexicographic ordering of their titles.
@@ -27,6 +30,9 @@ import org.dkpro.jwpl.api.exception.WikiTitleParsingException;
 public class PageTitleComparator
     implements Comparator<Page>
 {
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(MethodHandles.lookup().lookupClass());
 
     public int compare(Page o1, Page o2)
     {
@@ -36,7 +42,7 @@ public class PageTitleComparator
             retVal = o1.getTitle().getPlainTitle().compareTo(o2.getTitle().getPlainTitle());
         }
         catch (WikiTitleParsingException e) {
-            e.printStackTrace();
+            logger.error("Could not compare page titles.", e);
         }
         return retVal;
     }

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/TitleIterator.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/TitleIterator.java
@@ -17,12 +17,15 @@
  */
 package org.dkpro.jwpl.api;
 
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
 import org.dkpro.jwpl.api.exception.WikiTitleParsingException;
 import org.hibernate.Session;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An {@link Iterator} over {@link Title} objects.
@@ -30,6 +33,9 @@ import org.hibernate.Session;
 public class TitleIterator
     implements Iterator<Title>
 {
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(MethodHandles.lookup().lookupClass());
 
     private final TitleBuffer buffer;
 
@@ -131,7 +137,7 @@ public class TitleIterator
                 title = new Title(titleString);
             }
             catch (WikiTitleParsingException e) {
-                e.printStackTrace();
+                logger.error("Could not parse title '{}'.", titleString, e);
             }
             bufferOffset++;
             dataOffset++;

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/WikiConstants.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/WikiConstants.java
@@ -18,10 +18,13 @@
 package org.dkpro.jwpl.api;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.util.List;
 
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sweble.wikitext.engine.config.WikiConfig;
 import org.sweble.wikitext.engine.utils.DefaultConfigEnWp;
 import org.sweble.wikitext.engine.utils.LanguageConfigGenerator;
@@ -85,6 +88,9 @@ public interface WikiConstants
         west_frisian, wolof, wu, xhosa, yiddish, yoruba, zamboanga_chavacano, zazaki, zealandic,
         zhuang, zulu, _test;
 
+        private static final Logger logger = LoggerFactory
+                .getLogger(MethodHandles.lookup().lookupClass());
+
         /**
          * Configures a language specific configuration for parsing wikipedia pages.
          *
@@ -105,10 +111,8 @@ public interface WikiConstants
                     }
                 }
                 catch (IOException | ParserConfigurationException | SAXException e) {
-                    System.out.println(String.format(
-                            "Failed to create WikiConfig for language for %s, using default instead",
-                            langName));
-                    e.printStackTrace();
+                    logger.warn("Failed to create WikiConfig for language for {}, "
+                            + "using default instead", langName, e);
                 }
             }
             return config;

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Wikipedia.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Wikipedia.java
@@ -494,6 +494,9 @@ public class Wikipedia
         try {
             return new Category(this, hibernateId);
         } catch (WikiPageNotFoundException e) {
+            // The exception is used here as a control-flow signal only: the contract of this
+            // method is to return null if no category exists for the given id, so there is
+            // nothing to chain or log.
             return null;
         }
     }
@@ -533,7 +536,7 @@ public class Wikipedia
             try {
                 categorySet.add(new Category(this, hibernateId));
             } catch (WikiPageNotFoundException e) {
-                logger.warn("Could not load Category by it's HibernateId = '{}'", hibernateId);
+                logger.warn("Could not load Category by it's HibernateId = '{}'", hibernateId, e);
             }
         }
         return categorySet;
@@ -674,6 +677,8 @@ public class Wikipedia
         try {
             t = new Title(title);
         } catch (WikiTitleParsingException e) {
+            // The exception is used here as a control-flow signal only: a title that cannot be
+            // parsed cannot denote an existing page, so there is nothing to chain or log.
             return false;
         }
 

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/sweble/PlainTextConverter.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/sweble/PlainTextConverter.java
@@ -363,7 +363,7 @@ public class PlainTextConverter
             }
         }
         catch (LinkTargetException e) {
-            logger.warn(e.getLocalizedMessage());
+            logger.warn(e.getLocalizedMessage(), e);
         }
 
         write(link.getPrefix());

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/util/DbUtilities.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/util/DbUtilities.java
@@ -75,7 +75,7 @@ public class DbUtilities
             }
         }
         catch (SQLException e) {
-            logger.error("Table {} does not exist.", tableName, new RuntimeException(e));
+            logger.error("Table {} does not exist.", tableName, e);
         }
 
         return false;

--- a/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/CategoryDescendantsIteratorTest.java
+++ b/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/CategoryDescendantsIteratorTest.java
@@ -61,8 +61,7 @@ public class CategoryDescendantsIteratorTest
             cat = wiki.getCategory("UKP");
         }
         catch (WikiApiException e) {
-            e.printStackTrace();
-            fail("A WikiApiException occurred while getting the category 'UKP'");
+            fail("A WikiApiException occurred while getting the category 'UKP'", e);
         }
 
         List<Integer> expectedPageIds = new ArrayList<>();
@@ -97,8 +96,7 @@ public class CategoryDescendantsIteratorTest
             cat = wiki.getCategory("UKP");
         }
         catch (WikiApiException e) {
-            e.printStackTrace();
-            fail("A WikiApiException occurred while getting the category 'UKP'");
+            fail("A WikiApiException occurred while getting the category 'UKP'", e);
         }
 
         List<Integer> expectedPageIds = new ArrayList<>();

--- a/dkpro-jwpl-datamachine/src/main/java/org/dkpro/jwpl/datamachine/dump/version/SingleDumpVersionJDKIntKeyFactory.java
+++ b/dkpro-jwpl-datamachine/src/main/java/org/dkpro/jwpl/datamachine/dump/version/SingleDumpVersionJDKIntKeyFactory.java
@@ -43,6 +43,10 @@ public class SingleDumpVersionJDKIntKeyFactory
             dumpVersion = new SingleDumpVersionJDKGeneric<Integer, StringHashCodeJDK>(StringHashCodeJDK.class);
         }
         catch (Exception e) {
+            // Only reflective instantiation failures of the hard-wired hash algorithm class can
+            // occur here, which cannot happen for a type with a public no-arg constructor. The
+            // cause is intentionally not propagated because the factory contract does not permit
+            // throwing; a 'null' result signals the (unreachable) failure to the caller.
             dumpVersion = null;
         }
         return dumpVersion;

--- a/dkpro-jwpl-datamachine/src/main/java/org/dkpro/jwpl/datamachine/dump/version/SingleDumpVersionJDKLongKeyFactory.java
+++ b/dkpro-jwpl-datamachine/src/main/java/org/dkpro/jwpl/datamachine/dump/version/SingleDumpVersionJDKLongKeyFactory.java
@@ -43,6 +43,10 @@ public class SingleDumpVersionJDKLongKeyFactory
             dumpVersion = new SingleDumpVersionJDKGeneric<Long, StringHashCodeJBoss>(StringHashCodeJBoss.class);
         }
         catch (Exception e) {
+            // Only reflective instantiation failures of the hard-wired hash algorithm class can
+            // occur here, which cannot happen for a type with a public no-arg constructor. The
+            // cause is intentionally not propagated because the factory contract does not permit
+            // throwing; a 'null' result signals the (unreachable) failure to the caller.
             dumpVersion = null;
         }
         return dumpVersion;

--- a/dkpro-jwpl-datamachine/src/main/java/org/dkpro/jwpl/datamachine/dump/version/SingleDumpVersionJDKStringKeyFactory.java
+++ b/dkpro-jwpl-datamachine/src/main/java/org/dkpro/jwpl/datamachine/dump/version/SingleDumpVersionJDKStringKeyFactory.java
@@ -43,6 +43,10 @@ public class SingleDumpVersionJDKStringKeyFactory
             dumpVersion = new SingleDumpVersionJDKGeneric<String, StringHashCodeDisabled>(StringHashCodeDisabled.class);
         }
         catch (Exception e) {
+            // Only reflective instantiation failures of the hard-wired hash algorithm class can
+            // occur here, which cannot happen for a type with a public no-arg constructor. The
+            // cause is intentionally not propagated because the factory contract does not permit
+            // throwing; a 'null' result signals the (unreachable) failure to the caller.
             dumpVersion = null;
         }
         return dumpVersion;

--- a/dkpro-jwpl-datamachine/src/main/java/org/dkpro/jwpl/datamachine/dump/xml/DataMachineRevisionParser.java
+++ b/dkpro-jwpl-datamachine/src/main/java/org/dkpro/jwpl/datamachine/dump/xml/DataMachineRevisionParser.java
@@ -43,6 +43,8 @@ public class DataMachineRevisionParser
             revTextId = stream.readInt();
         }
         catch (EOFException e) {
+            // Reaching the end of the stream is the regular termination signal here, not an
+            // error. The exception therefore carries no information worth propagating.
             hasNext = false;
         }
         return hasNext;

--- a/dkpro-jwpl-mwdumper/src/main/java/org/dkpro/jwpl/mwdumper/dumper/Dumper.java
+++ b/dkpro-jwpl-mwdumper/src/main/java/org/dkpro/jwpl/mwdumper/dumper/Dumper.java
@@ -273,7 +273,7 @@ class Dumper
             return new OutputWrapper(conn);
         }
         catch (Exception e) {
-            throw new IOException(e.toString());
+            throw new IOException(e.toString(), e);
         }
     }
 

--- a/dkpro-jwpl-mwdumper/src/main/java/org/dkpro/jwpl/mwdumper/importer/NamespaceFilter.java
+++ b/dkpro-jwpl-mwdumper/src/main/java/org/dkpro/jwpl/mwdumper/importer/NamespaceFilter.java
@@ -57,6 +57,9 @@ public class NamespaceFilter
                 matches.put(key, trimmed);
             }
             catch (NumberFormatException e) {
+                // Not a numeric namespace key: fall back to matching the symbolic namespace
+                // names below. The exception is a mere control-flow signal here and carries no
+                // information beyond the input string, which is retained.
                 for (int key = 0; key < namespaceKeys.length; key++) {
                     if (trimmed.equalsIgnoreCase(namespaceKeys[key]))
                         matches.put(key, trimmed);

--- a/dkpro-jwpl-mwdumper/src/main/java/org/dkpro/jwpl/mwdumper/importer/SqlServerStream.java
+++ b/dkpro-jwpl-mwdumper/src/main/java/org/dkpro/jwpl/mwdumper/importer/SqlServerStream.java
@@ -47,7 +47,7 @@ public class SqlServerStream
             statement.execute(sql.toString());
         }
         catch (SQLException e) {
-            throw new IOException(e.toString());
+            throw new IOException(e.toString(), e);
         }
     }
 
@@ -57,10 +57,13 @@ public class SqlServerStream
             connection.close();
         }
         catch (SQLWarning e) {
-            e.printStackTrace();
+            // A warning on close is not fatal and is therefore handled here instead of being
+            // propagated. This module declares no logging facade, so it is reported on stderr
+            // like the other diagnostics of this module.
+            System.err.println("Warning while closing the SQL connection: " + e);
         }
         catch (SQLException e) {
-            throw new IOException(e.toString());
+            throw new IOException(e.toString(), e);
         }
     }
 

--- a/dkpro-jwpl-parser/src/main/java/org/dkpro/jwpl/parser/html/HtmlWriter.java
+++ b/dkpro-jwpl-parser/src/main/java/org/dkpro/jwpl/parser/html/HtmlWriter.java
@@ -367,6 +367,8 @@ public class HtmlWriter
             colspan = t.getTableElement(t.nrOfTableElements() - 1).getCol() + 1;
         }
         catch (Exception e) {
+            // The table carries no elements to derive the column count from - a single column is
+            // the correct fallback here, so the exception is intentionally not propagated.
             colspan = 1;
         }
 

--- a/dkpro-jwpl-parser/src/main/java/org/dkpro/jwpl/parser/selectiveaccess/SelectiveAccessHandler.java
+++ b/dkpro-jwpl-parser/src/main/java/org/dkpro/jwpl/parser/selectiveaccess/SelectiveAccessHandler.java
@@ -20,6 +20,7 @@ package org.dkpro.jwpl.parser.selectiveaccess;
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
@@ -40,6 +41,8 @@ import org.dkpro.jwpl.parser.SectionContainer;
 import org.dkpro.jwpl.parser.SectionContent;
 import org.dkpro.jwpl.parser.Span;
 import org.dkpro.jwpl.parser.Table;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.helpers.DefaultHandler;
 
 /**
@@ -47,6 +50,9 @@ import org.xml.sax.helpers.DefaultHandler;
  */
 public class SelectiveAccessHandler
 {
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(MethodHandles.lookup().lookupClass());
 
     public static final String COLON = ":";
     public static final String TAB = "\t";
@@ -408,7 +414,8 @@ public class SelectiveAccessHandler
             sp.parse(XMLFile, handler);
         }
         catch (Exception e) {
-            System.err.println(e);
+            logger.error("Could not load configuration from '{}'. Falling back to the default "
+                    + "configuration.", XMLFile, e);
             loadConfig();
         }
     }
@@ -456,7 +463,7 @@ public class SelectiveAccessHandler
             bw.close();
         }
         catch (IOException e) {
-            System.err.println(e);
+            logger.error("Could not write configuration to '{}'.", XMLFile, e);
         }
     }
 }

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/api/RevisionApi.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/api/RevisionApi.java
@@ -133,7 +133,8 @@ public class RevisionApi
                 }
                 catch (SQLException e) {
                     throw new WikiApiException(
-                            "To execute this query for the first time, you need to have write permissions for the database.");
+                            "To execute this query for the first time, you need to have write permissions for the database.",
+                            e);
                 }
                 // fill with information extracted from RevisionCounter field
                 statement = this.connection.prepareStatement(

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/api/RevisionIterator.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/api/RevisionIterator.java
@@ -373,7 +373,7 @@ public class RevisionIterator
                 catch (Exception e) {
                     this.previousRevision = null;
                     logger.error("Reconstruction failed - [ArticleId {}, RevisionId {}, RevisionCounter {}]",
-                            result.getInt(5), result.getInt(4), result.getInt(3));
+                            result.getInt(5), result.getInt(4), result.getInt(3), e);
                     return null;
                 }
 

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/api/chrono/ChronoIterator.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/api/chrono/ChronoIterator.java
@@ -29,12 +29,16 @@ import org.dkpro.jwpl.revisionmachine.api.Revision;
 import org.dkpro.jwpl.revisionmachine.api.RevisionAPIConfiguration;
 import org.dkpro.jwpl.revisionmachine.difftool.data.codec.RevisionDecoder;
 import org.dkpro.jwpl.revisionmachine.difftool.data.tasks.content.Diff;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * ChronoIterator Iterates articles in chronological order.
  */
 public class ChronoIterator
 {
+
+    private static final Logger logger = LoggerFactory.getLogger(ChronoIterator.class);
 
     /**
      * Reference to the configuration
@@ -334,10 +338,9 @@ public class ChronoIterator
                 }
                 catch (Exception e) {
 
-                    System.err.println("Reconstruction failed while retrieving"
-                            + " data to reconstruct <" + revisionIndex + ">" + "\r\n\t"
-                            + "[ArticleId " + result.getInt(5) + ", RevisionId " + result.getInt(4)
-                            + ", RevisionCounter " + result.getInt(3) + "]");
+                    logger.error(
+                            "Reconstruction failed while retrieving data to reconstruct <{}> - [ArticleId {}, RevisionId {}, RevisionCounter {}]",
+                            revisionIndex, result.getInt(5), result.getInt(4), result.getInt(3), e);
 
                     return null;
                 }

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/archivers/Bzip2Archiver.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/archivers/Bzip2Archiver.java
@@ -28,12 +28,16 @@ import java.io.OutputStream;
 
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Class provides basic bzip2 compression/decompression functionality
  */
 public class Bzip2Archiver
 {
+
+    private static final Logger logger = LoggerFactory.getLogger(Bzip2Archiver.class);
 
     // Size to write in memory while compressing (in bytes)
     private static final int COMPRESSION_CACHE = 10000000;
@@ -83,7 +87,7 @@ public class Bzip2Archiver
 
         }
         catch (IOException e) {
-            e.printStackTrace();
+            logger.error("Could not compress file [{}]", path, e);
         }
 
     }

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/common/logging/Logger.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/common/logging/Logger.java
@@ -25,6 +25,7 @@ import org.dkpro.jwpl.revisionmachine.common.exceptions.ErrorKeys;
 import org.dkpro.jwpl.revisionmachine.common.exceptions.LoggingException;
 import org.dkpro.jwpl.revisionmachine.difftool.config.ConfigurationKeys;
 import org.dkpro.jwpl.revisionmachine.difftool.config.ConfigurationManager;
+import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 /**
@@ -32,6 +33,11 @@ import org.slf4j.event.Level;
  */
 public class Logger
 {
+
+    /**
+     * Reference to a fallback logger which is used if this logger itself fails.
+     */
+    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(Logger.class);
 
     /**
      * Name of the logger
@@ -108,7 +114,7 @@ public class Logger
             writer.close();
         }
         catch (IOException ioe) {
-            ioe.printStackTrace();
+            logger.error("Could not close the log file of [{}]", consumerName, ioe);
         }
     }
 
@@ -121,7 +127,7 @@ public class Logger
             writer.flush();
         }
         catch (IOException ioe) {
-            ioe.printStackTrace();
+            logger.error("Could not flush the log file of [{}]", consumerName, ioe);
         }
     }
 
@@ -148,7 +154,7 @@ public class Logger
             this.writer.write(text);
         }
         catch (IOException ioe) {
-            ioe.printStackTrace();
+            logger.error("Could not write to the log file of [{}]", consumerName, ioe);
         }
     }
 
@@ -173,7 +179,8 @@ public class Logger
 
         }
         catch (LoggingException ex) {
-            ex.printStackTrace();
+            logger.error("Could not access the error logger [{}]", LoggingFactory.NAME_ERROR_LOGGER,
+                    ex);
         }
 
         if (logLevel.toInt() > level.toInt()) {
@@ -205,7 +212,8 @@ public class Logger
 
         }
         catch (LoggingException ex) {
-            ex.printStackTrace();
+            logger.error("Could not access the error logger [{}]", LoggingFactory.NAME_ERROR_LOGGER,
+                    ex);
         }
 
         if (logLevel.toInt() > level.toInt()) {
@@ -239,7 +247,7 @@ public class Logger
             this.writer.flush();
         }
         catch (IOException ioe) {
-            ioe.printStackTrace();
+            logger.error("Could not write to the log file of [{}]", consumerName, ioe);
         }
     }
 

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/common/logging/LoggingFactory.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/common/logging/LoggingFactory.java
@@ -22,12 +22,15 @@ import java.util.HashMap;
 import org.dkpro.jwpl.revisionmachine.common.exceptions.ErrorFactory;
 import org.dkpro.jwpl.revisionmachine.common.exceptions.ErrorKeys;
 import org.dkpro.jwpl.revisionmachine.common.exceptions.LoggingException;
+import org.slf4j.LoggerFactory;
 
 /**
  * The static references in this 'class' creates and controls all loggers.
  */
 public class LoggingFactory
 {
+
+    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(LoggingFactory.class);
 
     /**
      * Reference Map Consumer(-Name) -> Logger
@@ -53,7 +56,7 @@ public class LoggingFactory
             createLogger(LoggerType.ARTICLE_OUTPUT, NAME_ARTICLE_OUTPUT_LOGGER);
         }
         catch (LoggingException e) {
-            e.printStackTrace();
+            logger.error("Could not initialize the DiffTool loggers.", e);
             System.exit(-1);
         }
     }

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/DiffTool.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/DiffTool.java
@@ -17,14 +17,21 @@
  */
 package org.dkpro.jwpl.revisionmachine.difftool;
 
+import java.lang.invoke.MethodHandles;
+
 import org.dkpro.jwpl.revisionmachine.difftool.config.ConfigurationReader;
 import org.dkpro.jwpl.revisionmachine.difftool.config.gui.control.ConfigSettings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The command line tool to the start the DiffTool application.
  */
 public class DiffTool
 {
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(MethodHandles.lookup().lookupClass());
 
     private static final String USAGE = "Please use\n"
             + "\tjava -jar JWPLRevisionMachine.jar "
@@ -52,7 +59,7 @@ public class DiffTool
                 ConfigSettings config = new ConfigurationReader(args[0]).read();
                 new DiffToolThread(config).start();
             } catch (Exception e) {
-                e.printStackTrace();
+                logger.error("The DiffTool terminated abnormally.", e);
             }
         } else {
             // Arg for configuration file is missing

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/DiffToolThread.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/DiffToolThread.java
@@ -100,6 +100,8 @@ public class DiffToolThread
                     .getConfigParameter(ConfigurationKeys.MODE_STATISTICAL_OUTPUT);
         }
         catch (ConfigurationException e) {
+            // The parameter is optional: if it is not configured, the statistical output stays
+            // disabled. The exception carries no information beyond that, hence it is not chained.
             MODE_STATISTICAL_OUTPUT = false;
         }
 
@@ -254,7 +256,6 @@ public class DiffToolThread
             catch (SQLConsumerException e) {
 
                 SQLConsumerLogMessages.logSQLConsumerException(logger, e);
-                e.printStackTrace();
 
                 // Critical Exceptions
             }

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/config/gui/control/ConfigController.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/config/gui/control/ConfigController.java
@@ -19,6 +19,7 @@ package org.dkpro.jwpl.revisionmachine.difftool.config.gui.control;
 
 import java.io.FileWriter;
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 
 import javax.swing.JPanel;
 
@@ -29,12 +30,17 @@ import org.dkpro.jwpl.revisionmachine.difftool.config.gui.dialogs.XMLFileChooser
 import org.dkpro.jwpl.revisionmachine.difftool.config.gui.panels.AbstractPanel;
 import org.dkpro.jwpl.revisionmachine.difftool.data.SurrogateModes;
 import org.dkpro.jwpl.revisionmachine.difftool.data.archive.ArchiveDescription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Controller of the ConfigurationTool
  */
 public class ConfigController
 {
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(MethodHandles.lookup().lookupClass());
 
     /**
      * Reference to the ArchiveRegistry
@@ -457,7 +463,7 @@ public class ConfigController
             writer.flush();
 
           } catch (IOException ioe) {
-            ioe.printStackTrace();
+            logger.error("Could not write the configuration to [{}].", path, ioe);
             success = false;
           }
 

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/config/gui/control/ConfigSettings.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/config/gui/control/ConfigSettings.java
@@ -18,6 +18,7 @@
 package org.dkpro.jwpl.revisionmachine.difftool.config.gui.control;
 
 import java.io.File;
+import java.lang.invoke.MethodHandles;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -33,6 +34,8 @@ import org.dkpro.jwpl.revisionmachine.difftool.config.gui.data.ConfigEnum;
 import org.dkpro.jwpl.revisionmachine.difftool.data.OutputType;
 import org.dkpro.jwpl.revisionmachine.difftool.data.SurrogateModes;
 import org.dkpro.jwpl.revisionmachine.difftool.data.archive.ArchiveDescription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 /**
@@ -40,6 +43,9 @@ import org.slf4j.event.Level;
  */
 public class ConfigSettings
 {
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(MethodHandles.lookup().lookupClass());
 
     /**
      * Returns the type of the configuration
@@ -263,7 +269,7 @@ public class ConfigSettings
 
         }
         catch (Exception e) {
-            e.printStackTrace();
+            logger.error("Could not load the configuration from [{}].", path, e);
         }
     }
 }

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/article/reader/ArticleFilter.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/article/reader/ArticleFilter.java
@@ -17,6 +17,7 @@
  */
 package org.dkpro.jwpl.revisionmachine.difftool.consumer.article.reader;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
@@ -26,6 +27,8 @@ import java.util.Set;
 import org.dkpro.jwpl.revisionmachine.common.exceptions.ConfigurationException;
 import org.dkpro.jwpl.revisionmachine.difftool.config.ConfigurationKeys;
 import org.dkpro.jwpl.revisionmachine.difftool.config.ConfigurationManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Filter articles from unwanted namespaces.<br>
@@ -38,6 +41,9 @@ import org.dkpro.jwpl.revisionmachine.difftool.config.ConfigurationManager;
  */
 public class ArticleFilter
 {
+    private static final Logger logger = LoggerFactory
+            .getLogger(MethodHandles.lookup().lookupClass());
+
     private Map<Integer, String> namespaceMap;
 
     private Set<String> prefixesToAllow;
@@ -57,8 +63,7 @@ public class ArticleFilter
             config = ConfigurationManager.getInstance();
         }
         catch (ConfigurationException e) {
-            // TODO logger
-            System.err.print(e);
+            logger.error("Could not access the DiffTool configuration.", e);
         }
     }
 

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/article/reader/InputFactory.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/article/reader/InputFactory.java
@@ -22,6 +22,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.lang.invoke.MethodHandles;
 
 import org.dkpro.jwpl.revisionmachine.archivers.Bzip2Archiver;
 import org.dkpro.jwpl.revisionmachine.common.exceptions.ArticleReaderException;
@@ -32,6 +33,8 @@ import org.dkpro.jwpl.revisionmachine.difftool.config.ConfigurationKeys;
 import org.dkpro.jwpl.revisionmachine.difftool.config.ConfigurationManager;
 import org.dkpro.jwpl.revisionmachine.difftool.consumer.article.ArticleReaderInterface;
 import org.dkpro.jwpl.revisionmachine.difftool.data.archive.ArchiveDescription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This factory class contains methods to access an input medium.
@@ -40,6 +43,9 @@ import org.dkpro.jwpl.revisionmachine.difftool.data.archive.ArchiveDescription;
  */
 public class InputFactory
 {
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(MethodHandles.lookup().lookupClass());
 
     /**
      * Configuration parameter - Path to the 7Zip executable
@@ -70,7 +76,7 @@ public class InputFactory
 
         }
         catch (ConfigurationException e) {
-            e.printStackTrace();
+            logger.error("Could not access the DiffTool configuration.", e);
             System.exit(-1);
         }
     }
@@ -129,8 +135,7 @@ public class InputFactory
             reader = archiver.getDecompressionStream(archivePath, WIKIPEDIA_ENCODING);
         }
         catch (IOException e) {
-
-            e.printStackTrace();
+            logger.error("Could not open a BZip2 decompression stream for [{}].", archivePath, e);
         }
 
         return reader;

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/article/reader/WikipediaXMLReader.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/article/reader/WikipediaXMLReader.java
@@ -20,6 +20,7 @@ package org.dkpro.jwpl.revisionmachine.difftool.consumer.article.reader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -40,6 +41,8 @@ import org.dkpro.jwpl.revisionmachine.difftool.consumer.dump.SQLEscape;
 import org.dkpro.jwpl.revisionmachine.difftool.data.tasks.Task;
 import org.dkpro.jwpl.revisionmachine.difftool.data.tasks.TaskTypes;
 import org.dkpro.jwpl.revisionmachine.difftool.data.tasks.info.ArticleInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -53,6 +56,9 @@ import org.xml.sax.SAXException;
 public class WikipediaXMLReader
     implements ArticleReaderInterface
 {
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(MethodHandles.lookup().lookupClass());
 
     /**
      * Reference to the reader
@@ -227,10 +233,10 @@ public class WikipediaXMLReader
             }
         }
         catch (IOException e) {
-            System.err.println("Error reading namespaces from xml dump.");
+            logger.error("Error reading namespaces from xml dump.", e);
         }
         catch (ParserConfigurationException | SAXException e) {
-            System.err.println("Error parsing namespace data.");
+            logger.error("Error parsing namespace data.", e);
         }
     }
 

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/diff/calculation/DiffCalculator.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/diff/calculation/DiffCalculator.java
@@ -383,6 +383,8 @@ public class DiffCalculator
             }
         }
         catch (NullPointerException e) {
+            // A faulty revision without accessible text is skipped. The exception is only used to
+            // detect that condition and carries no additional information, hence it is not chained.
             return null;
         }
 

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/dump/codec/SQLEncoding.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/dump/codec/SQLEncoding.java
@@ -137,7 +137,8 @@ public class SQLEncoding
 
         }
         catch (Exception e) {
-            // Ignore
+            // Deliberately ignored: toString() must not fail. If the detailed representation
+            // cannot be built, the compact fallback representation below is returned instead.
         }
 
         return "<" + list.size() + ">\r\n" + query;

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/dump/writer/OutputFactory.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/dump/writer/OutputFactory.java
@@ -19,6 +19,7 @@ package org.dkpro.jwpl.revisionmachine.difftool.consumer.dump.writer;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.invoke.MethodHandles;
 
 import org.dkpro.jwpl.revisionmachine.archivers.Bzip2Archiver;
 import org.dkpro.jwpl.revisionmachine.common.exceptions.ConfigurationException;
@@ -27,9 +28,14 @@ import org.dkpro.jwpl.revisionmachine.common.exceptions.ErrorKeys;
 import org.dkpro.jwpl.revisionmachine.difftool.config.ConfigurationKeys;
 import org.dkpro.jwpl.revisionmachine.difftool.config.ConfigurationManager;
 import org.dkpro.jwpl.revisionmachine.difftool.data.OutputType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class OutputFactory
 {
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(MethodHandles.lookup().lookupClass());
 
     private static String PATH_PROGRAM_7ZIP = null;
     private static OutputType MODE_OUTPUT = null;
@@ -41,7 +47,7 @@ public class OutputFactory
             MODE_OUTPUT = (OutputType) config.getConfigParameter(ConfigurationKeys.MODE_OUTPUT);
         }
         catch (ConfigurationException e) {
-            e.printStackTrace();
+            logger.error("Could not access the DiffTool configuration.", e);
             System.exit(-1);
         }
     }
@@ -76,7 +82,7 @@ public class OutputFactory
             output = new Bzip2Archiver().getCompressionStream(archivePath);
         }
         catch (IOException e) {
-            e.printStackTrace();
+            logger.error("Could not open a BZip2 compression stream for [{}].", archivePath, e);
         }
         return output;
     }

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/index/IndexGenerator.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/index/IndexGenerator.java
@@ -30,12 +30,16 @@ import org.dkpro.jwpl.revisionmachine.api.Revision;
 import org.dkpro.jwpl.revisionmachine.api.RevisionAPIConfiguration;
 import org.dkpro.jwpl.revisionmachine.common.util.Time;
 import org.dkpro.jwpl.revisionmachine.difftool.config.OutputTypes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Generates the indices for the database.
  */
 public class IndexGenerator
 {
+
+    private static final Logger logger = LoggerFactory.getLogger(IndexGenerator.class);
 
     /**
      * Reference to the configuration
@@ -191,7 +195,7 @@ public class IndexGenerator
                 new IndexGenerator(config).generate();
             }
             catch (Exception e) {
-                e.printStackTrace();
+                logger.error("Index generation failed.", e);
             }
 
             System.out.println("TERMINATED");
@@ -215,7 +219,7 @@ public class IndexGenerator
             props.load(fis);
         }
         catch (IOException e) {
-            System.err.println("Could not load configuration file " + configFilePath);
+            logger.error("Could not load configuration file [{}]", configFilePath, e);
         }
         finally {
             if (fis != null) {
@@ -223,8 +227,8 @@ public class IndexGenerator
                     fis.close();
                 }
                 catch (IOException e) {
-                    System.err.println(
-                            "Error closing file stream of configuration file " + configFilePath);
+                    logger.error("Error closing file stream of configuration file [{}]",
+                            configFilePath, e);
                 }
             }
         }

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/index/Indexer.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/index/Indexer.java
@@ -194,7 +194,6 @@ public class Indexer
                     send();
                 }
                 catch (SQLException | IOException sql) {
-                    sql.printStackTrace();
                     throw new WikiApiException(sql);
                 }
             }
@@ -280,7 +279,6 @@ public class Indexer
 
         }
         catch (SQLException | IOException sql) {
-            sql.printStackTrace();
             throw new WikiApiException(sql);
         }
     }

--- a/dkpro-jwpl-timemachine/src/main/java/org/dkpro/jwpl/timemachine/domain/SettingsXML.java
+++ b/dkpro-jwpl-timemachine/src/main/java/org/dkpro/jwpl/timemachine/domain/SettingsXML.java
@@ -24,11 +24,14 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.invoke.MethodHandles;
 import java.util.Properties;
 
 import org.dkpro.jwpl.wikimachine.debug.ILogger;
 import org.dkpro.jwpl.wikimachine.domain.Configuration;
 import org.dkpro.jwpl.wikimachine.util.TimestampUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This is a utility class that generates a template for the configuration file<br>
@@ -36,6 +39,9 @@ import org.dkpro.jwpl.wikimachine.util.TimestampUtil;
  */
 public class SettingsXML
 {
+
+    private static final Logger LOG = LoggerFactory
+            .getLogger(MethodHandles.lookup().lookupClass());
 
     public static final String OUTPUT_DIRECTORY = "outputDirectory";
     public static final String CATEGORY_LINKS_FILE = "categoryLinksFile";
@@ -86,9 +92,11 @@ public class SettingsXML
             result.setEach(Integer.parseInt(properties.get(EACH).toString()));
         } catch (IOException ioe) {
             logger.log("Could not find config file " + configFile);
+            logger.log(ioe);
             result = null;
         } catch (NumberFormatException nfe) {
             logger.log("Could not read 'each' parameter - check the config file!");
+            logger.log(nfe);
             result = null;
         }
         return result;
@@ -113,6 +121,7 @@ public class SettingsXML
         }
         catch (IOException e) {
             logger.log("Could not find config file " + configFile);
+            logger.log(e);
             result = null;
         }
         return result;
@@ -125,7 +134,7 @@ public class SettingsXML
                 generateSample(args[0]);
             }
             catch (IOException e) {
-                e.printStackTrace();
+                LOG.error("Could not generate a sample configuration file at '{}'.", args[0], e);
             }
         }
 

--- a/dkpro-jwpl-timemachine/src/main/java/org/dkpro/jwpl/timemachine/dump/version/DumpVersionJDKIntKeyFactory.java
+++ b/dkpro-jwpl-timemachine/src/main/java/org/dkpro/jwpl/timemachine/dump/version/DumpVersionJDKIntKeyFactory.java
@@ -34,6 +34,10 @@ public class DumpVersionJDKIntKeyFactory
                     StringHashCodeJDK.class);
         }
         catch (Exception e) {
+            // Only reflective instantiation failures of the hard-wired hash algorithm class can
+            // occur here, which cannot happen for a type with a public no-arg constructor. The
+            // cause is intentionally not propagated because the factory contract does not permit
+            // throwing; a 'null' result signals the (unreachable) failure to the caller.
             dumpVersion = null;
         }
         return dumpVersion;

--- a/dkpro-jwpl-timemachine/src/main/java/org/dkpro/jwpl/timemachine/dump/version/DumpVersionJDKLongKeyFactory.java
+++ b/dkpro-jwpl-timemachine/src/main/java/org/dkpro/jwpl/timemachine/dump/version/DumpVersionJDKLongKeyFactory.java
@@ -34,6 +34,10 @@ public class DumpVersionJDKLongKeyFactory
                     StringHashCodeJBoss.class);
         }
         catch (Exception e) {
+            // Only reflective instantiation failures of the hard-wired hash algorithm class can
+            // occur here, which cannot happen for a type with a public no-arg constructor. The
+            // cause is intentionally not propagated because the factory contract does not permit
+            // throwing; a 'null' result signals the (unreachable) failure to the caller.
             dumpVersion = null;
         }
         return dumpVersion;

--- a/dkpro-jwpl-timemachine/src/main/java/org/dkpro/jwpl/timemachine/dump/version/DumpVersionJDKStringKeyFactory.java
+++ b/dkpro-jwpl-timemachine/src/main/java/org/dkpro/jwpl/timemachine/dump/version/DumpVersionJDKStringKeyFactory.java
@@ -34,6 +34,10 @@ public class DumpVersionJDKStringKeyFactory
                     StringHashCodeDisabled.class);
         }
         catch (Exception e) {
+            // Only reflective instantiation failures of the hard-wired hash algorithm class can
+            // occur here, which cannot happen for a type with a public no-arg constructor. The
+            // cause is intentionally not propagated because the factory contract does not permit
+            // throwing; a 'null' result signals the (unreachable) failure to the caller.
             dumpVersion = null;
         }
         return dumpVersion;

--- a/dkpro-jwpl-timemachine/src/main/java/org/dkpro/jwpl/timemachine/dump/xml/TimeMachineRevisionParser.java
+++ b/dkpro-jwpl-timemachine/src/main/java/org/dkpro/jwpl/timemachine/dump/xml/TimeMachineRevisionParser.java
@@ -37,6 +37,8 @@ public class TimeMachineRevisionParser
             revTimestamp = Revision.compressTime(stream.readLong());
         }
         catch (EOFException e) {
+            // Reaching the end of the stream is the regular termination signal here, not an
+            // error. The exception therefore carries no information worth propagating.
             hasNext = false;
         }
 

--- a/dkpro-jwpl-timemachine/src/main/java/org/dkpro/jwpl/timemachine/dump/xml/XMLDumpTableInputStreamThread.java
+++ b/dkpro-jwpl-timemachine/src/main/java/org/dkpro/jwpl/timemachine/dump/xml/XMLDumpTableInputStreamThread.java
@@ -134,6 +134,9 @@ class XMLDumpTableInputStreamThread
             isComplete = true;
         }
         catch (IOException e) {
+            // The rethrown exception dies with this thread - no caller ever joins it, the
+            // consumer only observes a broken pipe. Hence this log is the only record of the
+            // original cause and must not be removed as 'redundant'.
             logger.error(e.getMessage(), e);
             throw new RuntimeException(e);
         }

--- a/dkpro-jwpl-tutorial/src/main/java/org/dkpro/jwpl/tutorial/api/T1c_HelloWorld.java
+++ b/dkpro-jwpl-tutorial/src/main/java/org/dkpro/jwpl/tutorial/api/T1c_HelloWorld.java
@@ -52,6 +52,9 @@ public class T1c_HelloWorld
             wiki = new Wikipedia(dbConfig);
         }
         catch (WikiInitializationException e1) {
+            // The exception is handled here and not rethrown, so the stack trace printed below is
+            // the only record of the cause. The tutorial module deliberately pulls in no logging
+            // framework, hence the plain console output.
             System.out.println("Could not initialize Wikipedia.");
             e1.printStackTrace();
             System.exit(1);
@@ -64,6 +67,7 @@ public class T1c_HelloWorld
             System.out.println(page.getText());
         }
         catch (WikiApiException e) {
+            // Handled, not rethrown - see the comment above on why the trace is printed.
             System.out.println("Page " + title + " does not exist");
             e.printStackTrace();
             System.exit(1);

--- a/dkpro-jwpl-tutorial/src/main/java/org/dkpro/jwpl/tutorial/api/T2_PageInfo.java
+++ b/dkpro-jwpl-tutorial/src/main/java/org/dkpro/jwpl/tutorial/api/T2_PageInfo.java
@@ -53,7 +53,7 @@ public class T2_PageInfo
             page = wiki.getPage(title);
         }
         catch (WikiPageNotFoundException e) {
-            throw new WikiApiException("Page " + title + " does not exist");
+            throw new WikiApiException("Page " + title + " does not exist", e);
         }
 
         // the title of the page

--- a/dkpro-jwpl-tutorial/src/main/java/org/dkpro/jwpl/tutorial/api/T3_PageDetails.java
+++ b/dkpro-jwpl-tutorial/src/main/java/org/dkpro/jwpl/tutorial/api/T3_PageDetails.java
@@ -55,7 +55,7 @@ public class T3_PageDetails
             page = wiki.getPage(title);
         }
         catch (WikiPageNotFoundException e) {
-            throw new WikiApiException("Page " + title + " does not exist");
+            throw new WikiApiException("Page " + title + " does not exist", e);
         }
 
         StringBuilder sb = new StringBuilder();

--- a/dkpro-jwpl-tutorial/src/main/java/org/dkpro/jwpl/tutorial/api/T4_Categories.java
+++ b/dkpro-jwpl-tutorial/src/main/java/org/dkpro/jwpl/tutorial/api/T4_Categories.java
@@ -56,7 +56,7 @@ public class T4_Categories
             cat = wiki.getCategory(title);
         }
         catch (WikiPageNotFoundException e) {
-            throw new WikiApiException("Category " + title + " does not exist");
+            throw new WikiApiException("Category " + title + " does not exist", e);
         }
 
         StringBuilder sb = new StringBuilder();

--- a/dkpro-jwpl-tutorial/src/main/java/org/dkpro/jwpl/tutorial/api/T5_TownList.java
+++ b/dkpro-jwpl-tutorial/src/main/java/org/dkpro/jwpl/tutorial/api/T5_TownList.java
@@ -62,7 +62,7 @@ public class T5_TownList
             topCat = wiki.getCategory(title);
         }
         catch (WikiPageNotFoundException e) {
-            throw new WikiApiException("Category " + title + " does not exist");
+            throw new WikiApiException("Category " + title + " does not exist", e);
         }
 
         // Add the pages categorized under "Towns in Germany".

--- a/dkpro-jwpl-util/src/main/java/org/dkpro/jwpl/util/templates/RevisionPair.java
+++ b/dkpro-jwpl-util/src/main/java/org/dkpro/jwpl/util/templates/RevisionPair.java
@@ -18,6 +18,7 @@
 package org.dkpro.jwpl.util.templates;
 
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -26,6 +27,8 @@ import java.util.Objects;
 import org.dkpro.jwpl.revisionmachine.api.Revision;
 import org.dkpro.jwpl.util.templates.parser.ParseUtils;
 import org.dkpro.jwpl.util.templates.parser.SectionExtractor.ExtractedSection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Represents a pair of (adjacent) revisions. In the second pair part (=after) a template has been
@@ -34,6 +37,9 @@ import org.dkpro.jwpl.util.templates.parser.SectionExtractor.ExtractedSection;
 public class RevisionPair
     implements Serializable
 {
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(MethodHandles.lookup().lookupClass());
 
     private static final long serialVersionUID = -1958556838478438963L;
     private final Revision before;
@@ -156,8 +162,7 @@ public class RevisionPair
             // in the parser, which is not wrapped in a Compiler exception.
             // Therefore, we should catch all exceptions here and return the
             // TextPairs identified so far (if any)
-            System.err.println(ex.getMessage());
-            // TODO use logger!!
+            logger.error("Could not extract text pairs from revision pair.", ex);
         }
         return pairList;
     }

--- a/dkpro-jwpl-util/src/main/java/org/dkpro/jwpl/util/templates/WikipediaTemplateInfo.java
+++ b/dkpro-jwpl-util/src/main/java/org/dkpro/jwpl/util/templates/WikipediaTemplateInfo.java
@@ -17,6 +17,7 @@
  */
 package org.dkpro.jwpl.util.templates;
 
+import java.lang.invoke.MethodHandles;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -49,12 +50,17 @@ import org.dkpro.jwpl.revisionmachine.api.Revision;
 import org.dkpro.jwpl.revisionmachine.api.RevisionApi;
 import org.dkpro.jwpl.util.templates.RevisionPair.RevisionPairType;
 import org.dkpro.jwpl.util.templates.generator.GeneratorConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class gives access to the additional information created by the TemplateInfoGenerator.
  */
 public class WikipediaTemplateInfo
 {
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(MethodHandles.lookup().lookupClass());
 
     private final Wikipedia wiki;
     private RevisionApi revApi = null;
@@ -1083,6 +1089,11 @@ public class WikipediaTemplateInfo
             p = wiki.getPage(pageTitle);
         }
         catch (WikiApiException e) {
+            // The page does not exist (or cannot be retrieved) - by contract, this method then
+            // yields an empty result instead of failing. As the exception is not propagated,
+            // it is logged here as it would be lost otherwise.
+            logger.debug("Could not retrieve page [{}]. Returning an empty template name list.",
+                    pageTitle, e);
             return new ArrayList<>();
         }
         return getTemplateNamesFromPage(p);
@@ -1353,7 +1364,7 @@ public class WikipediaTemplateInfo
                         }
                         catch (WikiPageNotFoundException e) {
                             // current was probably the last revision already
-                            System.out.println("Succeeding revision not found.");
+                            logger.debug("Succeeding revision not found.", e);
                         }
                     }
                     if (type == RevisionPairType.addTemplate) {
@@ -1372,14 +1383,14 @@ public class WikipediaTemplateInfo
                         }
                         catch (WikiPageNotFoundException e) {
                             // current was probably the first revision already
-                            System.out.println("Preceding revision not found.");
+                            logger.debug("Preceding revision not found.", e);
                         }
                     }
                 }
             }
             catch (WikiPageNotFoundException e) {
                 // The revision from the template db is missing in the revision db.
-                System.err.println("Current revision (" + revId + ")not found.");
+                logger.warn("Current revision ({}) not found.", revId, e);
             }
         }
 
@@ -1579,7 +1590,7 @@ public class WikipediaTemplateInfo
         }
         catch (WikiApiException e) {
             close();
-            System.err.println("Could not reconnect. Closing connection...");
+            logger.error("Could not reconnect. Closing connection...", e);
         }
     }
 
@@ -1590,6 +1601,10 @@ public class WikipediaTemplateInfo
             res = state.executeQuery();
         }
         catch (Exception e) {
+            // The query failed - most likely due to a stale connection. Reconnect once and retry.
+            // The original failure is not propagated as the retry either succeeds or fails with
+            // its own exception, hence it is logged here to not lose that information.
+            logger.debug("Query execution failed. Reconnecting and retrying ...", e);
             reconnect();
             res = state.executeQuery();
         }

--- a/dkpro-jwpl-util/src/main/java/org/dkpro/jwpl/util/templates/generator/simple/TemplateInfoGeneratorStarter.java
+++ b/dkpro-jwpl-util/src/main/java/org/dkpro/jwpl/util/templates/generator/simple/TemplateInfoGeneratorStarter.java
@@ -21,6 +21,7 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
@@ -29,12 +30,17 @@ import java.util.regex.Pattern;
 
 import org.dkpro.jwpl.api.DatabaseConfiguration;
 import org.dkpro.jwpl.api.WikiConstants.Language;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Starter, which parsed configuration properties file and starts WikipediaTemplateInfoGenerator
  */
 public class TemplateInfoGeneratorStarter
 {
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(MethodHandles.lookup().lookupClass());
 
     private final static String FILTERING_ACTIVE_FOR_PAGES = "create_templates_for_pages";
     private final static String FILTERING_ACTIVE_FOR_REVISIONS = "create_templates_for_revisions";
@@ -131,6 +137,9 @@ public class TemplateInfoGeneratorStarter
                                 + "templateInfo.sql";
                     }
                     catch (IOException e) {
+                        // The canonical path cannot be determined - fall back to the plain path.
+                        logger.debug("Could not determine canonical path of [{}]. "
+                                + "Falling back to the plain path.", outfile, e);
                         output = outfile.getPath() + File.separatorChar + "templateInfo.sql";
                     }
                 }
@@ -174,7 +183,7 @@ public class TemplateInfoGeneratorStarter
                 generator.process();
             }
             catch (Exception e) {
-                e.printStackTrace();
+                logger.error("Could not generate the template information.", e);
             }
         }
     }
@@ -194,7 +203,7 @@ public class TemplateInfoGeneratorStarter
             props.load(fis);
         }
         catch (IOException e) {
-            System.err.println("Could not load configuration file " + configFilePath);
+            logger.error("Could not load configuration file [{}].", configFilePath, e);
         }
         return props;
     }

--- a/dkpro-jwpl-util/src/main/java/org/dkpro/jwpl/util/templates/parser/SectionExtractionTest.java
+++ b/dkpro-jwpl-util/src/main/java/org/dkpro/jwpl/util/templates/parser/SectionExtractionTest.java
@@ -17,6 +17,7 @@
  */
 package org.dkpro.jwpl.util.templates.parser;
 
+import java.lang.invoke.MethodHandles;
 import java.util.List;
 
 import org.dkpro.jwpl.api.DatabaseConfiguration;
@@ -24,9 +25,14 @@ import org.dkpro.jwpl.api.Page;
 import org.dkpro.jwpl.api.WikiConstants;
 import org.dkpro.jwpl.api.Wikipedia;
 import org.dkpro.jwpl.util.templates.parser.SectionExtractor.ExtractedSection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SectionExtractionTest
 {
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(MethodHandles.lookup().lookupClass());
 
     /**
      * @param args
@@ -51,7 +57,7 @@ public class SectionExtractionTest
 
         }
         catch (Exception e) {
-            e.printStackTrace();
+            logger.error("Could not extract sections.", e);
         }
 
     }

--- a/dkpro-jwpl-util/src/main/java/org/dkpro/jwpl/util/templates/parser/SectionExtractor.java
+++ b/dkpro-jwpl-util/src/main/java/org/dkpro/jwpl/util/templates/parser/SectionExtractor.java
@@ -200,7 +200,9 @@ public class SectionExtractor
             }
         }
         catch (LinkTargetException e) {
-            // Ignore
+            // The link target is malformed and cannot be resolved to a page title. As this
+            // visitor renders a best-effort plain text representation, such a link is simply
+            // skipped and the remaining content is processed.
         }
     }
 

--- a/dkpro-jwpl-wikimachine/src/main/java/org/dkpro/jwpl/wikimachine/debug/AbstractLogger.java
+++ b/dkpro-jwpl-wikimachine/src/main/java/org/dkpro/jwpl/wikimachine/debug/AbstractLogger.java
@@ -28,6 +28,12 @@ public abstract class AbstractLogger
 {
 
     /**
+     * Upper bound for the number of chained causes rendered by
+     * {@link #createThrowableMessage(Throwable)}.
+     */
+    private static final int MAX_CAUSE_DEPTH = 32;
+
+    /**
      * Checks whether a {@link Class} is throwable or not.
      * @param c The class to investigate.
      * @return {@code true} if {@code c} is throwable, {@code false} otherwise.
@@ -66,6 +72,18 @@ public abstract class AbstractLogger
         for (StackTraceElement currentTrace : e.getStackTrace()) {
             message.append('\n');
             message.append(currentTrace);
+        }
+        // Render the chained causes as well - otherwise the root of the problem is lost.
+        // The depth is bounded so that a (pathological) cyclic cause chain cannot loop forever.
+        int depth = 0;
+        for (Throwable cause = e.getCause(); cause != null
+                && depth < MAX_CAUSE_DEPTH; cause = cause.getCause(), depth++) {
+            message.append("\n\nCaused by: ");
+            message.append(cause);
+            for (StackTraceElement currentTrace : cause.getStackTrace()) {
+                message.append('\n');
+                message.append(currentTrace);
+            }
         }
         return message.toString();
     }

--- a/dkpro-jwpl-wikimachine/src/main/java/org/dkpro/jwpl/wikimachine/decompression/UniversalDecompressor.java
+++ b/dkpro-jwpl-wikimachine/src/main/java/org/dkpro/jwpl/wikimachine/decompression/UniversalDecompressor.java
@@ -32,6 +32,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Factory to create {@link InputStream} depending on the filename's extension. If
  * there are a supported archive type we decorate {@link FileInputStream} with special
@@ -58,6 +61,8 @@ import java.util.Properties;
 public class UniversalDecompressor
     implements IDecompressor
 {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UniversalDecompressor.class);
 
     /**
      * Placeholder for compressed file path in external command
@@ -134,8 +139,10 @@ public class UniversalDecompressor
         try {
           loadExternal(Files.newInputStream(externalConfig, StandardOpenOption.READ));
         }
-        catch (IOException ignore) {
-          // silently ignore it
+        catch (IOException e) {
+          // The external configuration is optional: if it cannot be opened, only the
+          // internally supported archive formats remain available, which is a valid state.
+          LOG.debug("Could not open external decompressor configuration '{}'.", externalConfig, e);
         }
     }
 
@@ -151,8 +158,10 @@ public class UniversalDecompressor
             externalSupport.put(key, properties.getProperty(key));
           }
         }
-        catch (IOException ignore) {
-            // silently ignore it
+        catch (IOException e) {
+            // The external configuration is optional: if it cannot be parsed, only the
+            // internally supported archive formats remain available, which is a valid state.
+            LOG.debug("Could not read external decompressor configuration.", e);
         }
     }
 
@@ -205,8 +214,10 @@ public class UniversalDecompressor
             Process externalProcess = Runtime.getRuntime().exec(command);
             result = externalProcess.getInputStream();
         }
-        catch (IOException ignore) {
-          ignore.printStackTrace();
+        catch (IOException e) {
+          // Handled here: the caller is signalled by the 'null' return value, so this is the
+          // only place the underlying cause is recorded.
+          LOG.error("Could not start the external decompressor for '{}'.", fileName, e);
         }
         return result;
     }
@@ -223,7 +234,10 @@ public class UniversalDecompressor
         try {
             result = new BufferedInputStream(new FileInputStream(fileName));
         }
-        catch (IOException ignore) {
+        catch (IOException e) {
+            // Handled here: the caller is signalled by the 'null' return value, so this is the
+            // only place the underlying cause is recorded.
+            LOG.error("Could not open '{}' for reading.", fileName, e);
         }
 
         return result;

--- a/dkpro-jwpl-wikimachine/src/main/java/org/dkpro/jwpl/wikimachine/dump/version/IDumpVersionDataFactory.java
+++ b/dkpro-jwpl-wikimachine/src/main/java/org/dkpro/jwpl/wikimachine/dump/version/IDumpVersionDataFactory.java
@@ -66,7 +66,7 @@ public interface IDumpVersionDataFactory extends IDumpVersionFactory {
           return c.getDeclaredConstructor().newInstance();
       } catch (ClassNotFoundException | NoSuchMethodException | InstantiationException |
                InvocationTargetException | IllegalAccessException e) {
-        throw new RuntimeException("Errors during creation of IDumpVersionDataFactory instance!");
+        throw new RuntimeException("Errors during creation of IDumpVersionDataFactory instance!", e);
       }
   }
 }

--- a/dkpro-jwpl-wikimachine/src/main/java/org/dkpro/jwpl/wikimachine/dump/version/IDumpVersionTimeFactory.java
+++ b/dkpro-jwpl-wikimachine/src/main/java/org/dkpro/jwpl/wikimachine/dump/version/IDumpVersionTimeFactory.java
@@ -66,7 +66,7 @@ public interface IDumpVersionTimeFactory extends IDumpVersionFactory {
       return c.getDeclaredConstructor().newInstance();
     } catch (ClassNotFoundException | NoSuchMethodException | InstantiationException |
              InvocationTargetException | IllegalAccessException e) {
-      throw new RuntimeException("Errors during creation of IDumpVersionDataFactory instance!");
+      throw new RuntimeException("Errors during creation of IDumpVersionDataFactory instance!", e);
     }
   }
 }

--- a/dkpro-jwpl-wikimachine/src/main/java/org/dkpro/jwpl/wikimachine/dump/xml/PageParser.java
+++ b/dkpro-jwpl-wikimachine/src/main/java/org/dkpro/jwpl/wikimachine/dump/xml/PageParser.java
@@ -98,6 +98,7 @@ public class PageParser
             pageIsRedirect = stream.readBoolean();
         }
         catch (EOFException e) {
+            // Not an error: reaching the end of the stream is how the last row is detected.
             hasNext = false;
         }
         return hasNext;

--- a/dkpro-jwpl-wikimachine/src/main/java/org/dkpro/jwpl/wikimachine/dump/xml/TextParser.java
+++ b/dkpro-jwpl-wikimachine/src/main/java/org/dkpro/jwpl/wikimachine/dump/xml/TextParser.java
@@ -78,6 +78,7 @@ public class TextParser
             oldText = stream.readUTFAsArray();
         }
         catch (EOFException e) {
+            // Not an error: reaching the end of the stream is how the last row is detected.
             hasNext = false;
         }
         return hasNext;

--- a/dkpro-jwpl-wikimachine/src/main/java/org/dkpro/jwpl/wikimachine/util/Redirects.java
+++ b/dkpro-jwpl-wikimachine/src/main/java/org/dkpro/jwpl/wikimachine/util/Redirects.java
@@ -153,7 +153,7 @@ public class Redirects
         }
         catch (Exception e) {
             redirectString = null;
-            logger.debug("Error in Redirects ignored");
+            logger.debug("Error in Redirects ignored", e);
         }
 
         return redirectString;

--- a/dkpro-jwpl-wikimachine/src/main/java/org/dkpro/jwpl/wikimachine/util/TimestampUtil.java
+++ b/dkpro-jwpl-wikimachine/src/main/java/org/dkpro/jwpl/wikimachine/util/TimestampUtil.java
@@ -43,7 +43,8 @@ public abstract class TimestampUtil
             time = sdf.parse(mediaWikiString).getTime();
         }
         catch (ParseException e) {
-            // Ignore
+            // Intentionally ignored: this method is contractually total and falls back to the
+            // epoch for input that does not match the MediaWiki timestamp format.
         }
 
         return new Timestamp(time);


### PR DESCRIPTION
Fixes #187.

Applies the policy from the issue across the codebase: when an exception is caught and a new one is thrown, the original is chained in as the cause, and where an exception is chained and rethrown it is no longer logged at the lower level as well.

81 sites across all nine modules:

| | |
|---|---:|
| caught exception discarded entirely (swallowed, or logged by message only) | 39 |
| `printStackTrace` / `System.out` / `System.err` in `src/main` | 24 |
| new exception constructed while dropping the caught one | 14 |
| log-then-throw, where the same exception would be logged twice | 4 |

The largest category is not cause-dropping but information loss at handling sites — `catch (X e) { logger.warn("...", id); }` discarding `e`, or `logger.warn(e.getLocalizedMessage())` keeping the message and losing the trace. Where a swallow is correct, the control flow is unchanged and a comment now documents why, as the issue asks for.

No exception type, control flow or public signature changes, and no new dependency. Every exception class already offered a `(String, Throwable)` constructor, so none had to be added. In tests, `e.printStackTrace(); fail(msg)` becomes `fail(msg, e)` — no assertion is weakened.

The remaining catch sites were reviewed and deliberately left: they are either already correct, or genuine handling points where the log is the only record and removing it would lose the event.

Two observations outside the scope of this change, worth separate issues:

- Both CLI mains catch `Exception`, log it and fall through to a zero exit code, so a failed run still reports success to a calling script.
- `dkpro-jwpl-mwdumper` is a fork of Wikimedia's mwdumper, so its changes here diverge from upstream. They are limited to genuine cause-dropping and swallowing, but the divergence is worth a deliberate decision.