### PR TITLE
Resolve link titles without loading the linked pages

### DIFF
--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Page.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Page.java
@@ -392,6 +392,21 @@ public class Page
     }
 
     /**
+     * Returns the titles of the pages that have a link pointing to this page.
+     * <p>
+     * This is a more efficient shortcut for collecting {@link Page#getTitle()} over
+     * {@link Page#getInlinks()}, as that would load every linking page - article text included -
+     * just to read its title. As with {@link Page#getInlinks()}, inlinks that do not come from an
+     * existing page are not part of the result.
+     *
+     * @return The titles of the pages that have a link pointing to this page.
+     */
+    public Set<Title> getInlinkTitles()
+    {
+        return new HashSet<>(wiki.getTitles(getInlinkIDs()).values());
+    }
+
+    /**
      * Returns the set of pages that are linked from this page. Outlinks in a page might also point
      * to non-existing pages. They are not included in the result set. <b>Warning:</b> Do not use
      * this for getting the number of outlinks with {@link Page#getOutlinks()}.size(). This is too
@@ -463,6 +478,21 @@ public class Page
 
         session.getTransaction().commit();
         return tmpSet;
+    }
+
+    /**
+     * Returns the titles of the pages that are linked from this page.
+     * <p>
+     * This is a more efficient shortcut for collecting {@link Page#getTitle()} over
+     * {@link Page#getOutlinks()}, as that would load every linked page - article text included -
+     * just to read its title. As with {@link Page#getOutlinks()}, outlinks pointing to
+     * non-existing pages are not part of the result.
+     *
+     * @return The titles of the pages that are linked from this page.
+     */
+    public Set<Title> getOutlinkTitles()
+    {
+        return new HashSet<>(wiki.getTitles(getOutlinkIDs()).values());
     }
 
     /**

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Wikipedia.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Wikipedia.java
@@ -234,11 +234,23 @@ public class Wikipedia
             // the session once its transaction completes, so it must not be reused across batches.
             Session session = this.__getHibernateSession();
             session.beginTransaction();
-            List<Object[]> rows = session
-                    .createQuery("select p.pageId, p.name from Page as p where p.pageId in (:ids)",
-                            Object[].class)
-                    .setParameterList("ids", batch).list();
-            session.getTransaction().commit();
+            List<Object[]> rows;
+            try {
+                rows = session
+                        .createQuery(
+                                "select p.pageId, p.name from Page as p where p.pageId in (:ids)",
+                                Object[].class)
+                        .setParameterList("ids", batch).list();
+                session.getTransaction().commit();
+            } catch (RuntimeException e) {
+                // A transaction left open would poison the thread-bound session for every later
+                // call on this thread, so callers that log the failure and move on to the next
+                // page would fail from here on for an unrelated reason.
+                if (session.getTransaction().isActive()) {
+                    session.getTransaction().rollback();
+                }
+                throw e;
+            }
 
             for (Object[] row : rows) {
                 Integer pageId = (Integer) row[0];

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Wikipedia.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Wikipedia.java
@@ -18,6 +18,8 @@
 package org.dkpro.jwpl.api;
 
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -54,6 +56,14 @@ public class Wikipedia
     // Note well: The whitespace at the beginning of this constant is here on purpose. Do NOT remove
     // it!
     static final String SQL_COLLATION = " COLLATE utf8mb4_bin"; /* " COLLATE utf8_bin"; */
+
+    /**
+     * Upper bound for the number of page ids bound into a single {@code in (..)} clause of
+     * {@link Wikipedia#getTitles(Collection)}. Pages with several thousand outgoing links exist,
+     * and neither the JDBC drivers nor the query planners deal well with parameter lists of that
+     * size.
+     */
+    private static final int TITLE_BATCH_SIZE = 500;
 
     private final Language language;
     private final DatabaseConfiguration dbConfig;
@@ -195,6 +205,55 @@ public class Wikipedia
             throw new WikiPageNotFoundException();
         }
         return new Title(returnValue);
+    }
+
+    /**
+     * Resolves the titles of many pages at once, without loading the pages themselves.
+     * <p>
+     * Obtaining the same titles via {@link Wikipedia#getPage(int)} and {@link Page#getTitle()}
+     * costs one full entity load - article text included - per page. This reads nothing but the
+     * page names, in one query per {@value Wikipedia#TITLE_BATCH_SIZE} ids.
+     * <p>
+     * Ids that have no matching page are absent from the result, as are pages whose name cannot be
+     * parsed into a {@link Title}. Callers that need to tell those cases apart have to compare the
+     * key set of the result against the ids they passed in.
+     *
+     * @param pageIds The ids of the pages to resolve titles for. Must not be {@code null}.
+     * @return The resolved titles, keyed by page id. Never {@code null}.
+     */
+    public Map<Integer, Title> getTitles(Collection<Integer> pageIds) {
+        Map<Integer, Title> titles = new HashMap<>();
+        if (pageIds.isEmpty()) {
+            return titles;
+        }
+
+        List<Integer> ids = new ArrayList<>(pageIds);
+        for (int from = 0; from < ids.size(); from += TITLE_BATCH_SIZE) {
+            List<Integer> batch = ids.subList(from, Math.min(from + TITLE_BATCH_SIZE, ids.size()));
+            // Re-acquired per batch on purpose: the thread-bound session context unbinds and closes
+            // the session once its transaction completes, so it must not be reused across batches.
+            Session session = this.__getHibernateSession();
+            session.beginTransaction();
+            List<Object[]> rows = session
+                    .createQuery("select p.pageId, p.name from Page as p where p.pageId in (:ids)",
+                            Object[].class)
+                    .setParameterList("ids", batch).list();
+            session.getTransaction().commit();
+
+            for (Object[] row : rows) {
+                Integer pageId = (Integer) row[0];
+                String name = (String) row[1];
+                try {
+                    titles.put(pageId, new Title(name));
+                } catch (WikiTitleParsingException e) {
+                    // A single unparsable name must not cost the caller the remaining titles.
+                    // This is the only record of the failure, so the exception is logged with it.
+                    logger.warn("Could not parse the title '{}' of the page with page id {}", name,
+                            pageId, e);
+                }
+            }
+        }
+        return titles;
     }
 
     /**

--- a/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/PageTest.java
+++ b/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/PageTest.java
@@ -27,6 +27,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.dkpro.jwpl.api.exception.WikiApiException;
 import org.dkpro.jwpl.api.exception.WikiPageNotFoundException;
@@ -291,6 +292,69 @@ public class PageTest
         assertNotNull(outlinkIDs);
         assertFalse(outlinkIDs.isEmpty());
         assertEquals(1, outlinkIDs.size());
+    }
+
+    @Test
+    public void testGetOutlinkTitles()
+    {
+        Set<Title> outlinkTitles = page.getOutlinkTitles();
+        assertNotNull(outlinkTitles);
+        assertEquals(1, outlinkTitles.size());
+        assertEquals("Torsten Zesch", outlinkTitles.iterator().next().getPlainTitle());
+    }
+
+    @Test
+    public void testGetOutlinkTitlesZero()
+    {
+        Set<Title> outlinkTitles = fetchPage("Unconnected_page").getOutlinkTitles();
+        assertNotNull(outlinkTitles);
+        assertTrue(outlinkTitles.isEmpty());
+    }
+
+    @Test
+    public void testGetOutlinkTitlesSkipsNonExistingPages()
+    {
+        // Two of the three outlinks point at existing pages, the third one (page id 1012) does not.
+        Page p = fetchPage("Christoph_Mueller");
+        assertEquals(3, p.getOutlinkIDs().size());
+        assertEquals(plainTitles(p.getOutlinks()), toPlainTitles(p.getOutlinkTitles()));
+        assertEquals(Set.of("Exploring the Potential of Semantic Relatedness in Information Retrieval",
+                "Semantic Information Retrieval"), toPlainTitles(p.getOutlinkTitles()));
+    }
+
+    @Test
+    public void testGetInlinkTitles()
+    {
+        Set<Title> inlinkTitles = page.getInlinkTitles();
+        assertNotNull(inlinkTitles);
+        assertEquals(3, inlinkTitles.size());
+        assertEquals(Set.of("Anouar Haha", "Torsten Zesch", "Demo of Wikipedia API"),
+                toPlainTitles(inlinkTitles));
+    }
+
+    @Test
+    public void testGetInlinkTitlesZero()
+    {
+        Set<Title> inlinkTitles = fetchPage("Unconnected_page").getInlinkTitles();
+        assertNotNull(inlinkTitles);
+        assertTrue(inlinkTitles.isEmpty());
+    }
+
+    private Set<String> toPlainTitles(Set<Title> titles)
+    {
+        return titles.stream().map(Title::getPlainTitle).collect(Collectors.toSet());
+    }
+
+    private Set<String> plainTitles(Set<Page> pages)
+    {
+        return pages.stream().map(p -> {
+            try {
+                return p.getTitle().getPlainTitle();
+            }
+            catch (WikiTitleParsingException e) {
+                throw new IllegalStateException(e);
+            }
+        }).collect(Collectors.toSet());
     }
 
     @Test

--- a/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/WikipediaTest.java
+++ b/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/WikipediaTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.invoke.MethodHandles;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -643,6 +644,42 @@ public class WikipediaTest
         catch (WikiApiException ae) {
             fail("Encountered WikiApiException: " + ae.getLocalizedMessage(), ae);
         }
+    }
+
+    @Test
+    public void testGetTitlesForPageIds()
+    {
+        Map<Integer, Title> titles = wiki.getTitles(List.of(1014, 1022, 1041));
+        assertEquals(3, titles.size());
+        assertEquals("Wikipedia API", titles.get(1014).getPlainTitle());
+        assertEquals("Torsten Zesch", titles.get(1022).getPlainTitle());
+        assertEquals("UKP", titles.get(1041).getPlainTitle());
+    }
+
+    @Test
+    public void testGetTitlesForPageIdsEmpty()
+    {
+        Map<Integer, Title> titles = wiki.getTitles(Collections.emptyList());
+        assertNotNull(titles);
+        assertTrue(titles.isEmpty());
+    }
+
+    @Test
+    public void testGetTitlesForPageIdsSkipsUnknownIds()
+    {
+        // Page id 1012 has no matching page, so it must be absent instead of mapping to null.
+        Map<Integer, Title> titles = wiki.getTitles(List.of(1014, 1012));
+        assertEquals(1, titles.size());
+        assertTrue(titles.containsKey(1014));
+        assertFalse(titles.containsKey(1012));
+    }
+
+    @Test
+    public void testGetTitlesForPageIdsMatchesGetTitle() throws WikiApiException
+    {
+        int pageId = 1022;
+        assertEquals(wiki.getTitle(pageId).getPlainTitle(),
+                wiki.getTitles(List.of(pageId)).get(pageId).getPlainTitle());
     }
 
     private void checkGetPageByExactTitle(String pageTitle) throws WikiApiException

--- a/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/WikipediaTest.java
+++ b/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/WikipediaTest.java
@@ -675,6 +675,16 @@ public class WikipediaTest
     }
 
     @Test
+    public void testGetTitlesForPageIdsWithRedirects()
+    {
+        // Page id 101 is reachable under two names ('Net_Centric_Systems' and 'NCS') and therefore
+        // has two PageMapLine rows. Resolving titles must yield the canonical page name regardless.
+        Map<Integer, Title> titles = wiki.getTitles(List.of(101));
+        assertEquals(1, titles.size());
+        assertEquals("Net Centric Systems", titles.get(101).getPlainTitle());
+    }
+
+    @Test
     public void testGetTitlesForPageIdsMatchesGetTitle() throws WikiApiException
     {
         int pageId = 1022;


### PR DESCRIPTION
**What's in the PR**

* `Wikipedia.getTitles(Collection<Integer>)` → `Map<Integer, Title>`, a bulk title lookup that reads nothing but the page names. One projection query per batch of 500 ids, instead of one full entity load — article text included — per page.
* `Page.getOutlinkTitles()` and `Page.getInlinkTitles()` → `Set<Title>`, thin wrappers over it. The inlink side is there because every other link accessor on `Page` comes as a pair (`getInlinks`/`getOutlinks`, `getInlinkIDs`/`getOutlinkIDs`, `getNumberOfInlinks`/`getNumberOfOutlinks`).

Motivation: a caller that walks the link graph to collect titles currently pays a 1+N entity load, dragging every linked article's text across the wire to read one string. The alternative is for the caller to hand-write HQL against `org.dkpro.jwpl.api.hibernate.Page` and reach through `WikiHibernateUtil` — which works today, but couples an external project to JWPL's internal OR mapping with nothing at compile time to catch a rename. Keeping the query in JWPL makes that drift a build failure here instead of a runtime failure there.
