### PR TITLE
#504: Also lift jdk.xml.maxGeneralEntitySizeLimit in the CLI tools

### DIFF
--- a/dkpro-jwpl-datamachine/src/main/java/org/dkpro/jwpl/datamachine/domain/JWPLDataMachine.java
+++ b/dkpro-jwpl-datamachine/src/main/java/org/dkpro/jwpl/datamachine/domain/JWPLDataMachine.java
@@ -32,7 +32,14 @@ import org.dkpro.jwpl.wikimachine.factory.IEnvironmentFactory;
 public class JWPLDataMachine
 {
 
-    private static final String PROP_ENTITY_SIZE_LIMIT = "jdk.xml.totalEntitySizeLimit";
+    private static final String PROP_TOTAL_ENTITY_SIZE_LIMIT = "jdk.xml.totalEntitySizeLimit";
+
+    private static final String PROP_MAX_GENERAL_ENTITY_SIZE_LIMIT = "jdk.xml.maxGeneralEntitySizeLimit";
+
+    /**
+     * Indicates that the corresponding JAXP limit is not enforced.
+     */
+    private static final String NO_LIMIT = "0";
 
     private static final int LANG_ARG = 0;
     private static final int MAINCATEGORY_ARG = 1;
@@ -76,7 +83,10 @@ public class JWPLDataMachine
     public static void main(String[] args)
     {
         if (args.length > 3) {
-            System.setProperty(PROP_ENTITY_SIZE_LIMIT, "0"); // compensates for #201
+            // The dumps processed here are trusted input whose entity sizes legitimately
+            // exceed the JAXP defaults. See #201 and #504.
+            System.setProperty(PROP_TOTAL_ENTITY_SIZE_LIMIT, NO_LIMIT);
+            System.setProperty(PROP_MAX_GENERAL_ENTITY_SIZE_LIMIT, NO_LIMIT);
             Configuration config = getConfigFromArgs(args);
             DataMachineFiles files = new DataMachineFiles(logger);
             files.setDataDirectory(args[DATADIR_ARG]);

--- a/dkpro-jwpl-timemachine/src/main/java/org/dkpro/jwpl/timemachine/domain/JWPLTimeMachine.java
+++ b/dkpro-jwpl-timemachine/src/main/java/org/dkpro/jwpl/timemachine/domain/JWPLTimeMachine.java
@@ -32,7 +32,14 @@ import org.dkpro.jwpl.wikimachine.factory.IEnvironmentFactory;
 public class JWPLTimeMachine
 {
 
-    private static final String PROP_ENTITY_SIZE_LIMIT = "jdk.xml.totalEntitySizeLimit";
+    private static final String PROP_TOTAL_ENTITY_SIZE_LIMIT = "jdk.xml.totalEntitySizeLimit";
+
+    private static final String PROP_MAX_GENERAL_ENTITY_SIZE_LIMIT = "jdk.xml.maxGeneralEntitySizeLimit";
+
+    /**
+     * Indicates that the corresponding JAXP limit is not enforced.
+     */
+    private static final String NO_LIMIT = "0";
 
     private static final IEnvironmentFactory environmentFactory;
     private static final ILogger logger;
@@ -67,7 +74,10 @@ public class JWPLTimeMachine
     {
         try {
             if (checkArgs(args)) {
-                System.setProperty(PROP_ENTITY_SIZE_LIMIT, "0"); // compensates for #201
+                // The dumps processed here are trusted input whose entity sizes legitimately
+                // exceed the JAXP defaults. See #201 and #504.
+                System.setProperty(PROP_TOTAL_ENTITY_SIZE_LIMIT, NO_LIMIT);
+                System.setProperty(PROP_MAX_GENERAL_ENTITY_SIZE_LIMIT, NO_LIMIT);
                 logger.log("parsing configuration file....");
                 Configuration config = SettingsXML.loadConfiguration(args[0], logger);
                 TimeMachineFiles files = SettingsXML.loadFiles(args[0], logger);


### PR DESCRIPTION
Closes #504. Follow-up to #201.

`JWPLDataMachine` and `JWPLTimeMachine` lifted only `jdk.xml.totalEntitySizeLimit` before parsing a dump. The JAXP secure-processing limits are enforced independently, so a large dump could still trip the *per-entity* limit even with the cumulative one disabled.

Changes:
- Set `jdk.xml.maxGeneralEntitySizeLimit` to `0` (no limit) alongside `jdk.xml.totalEntitySizeLimit` in both CLI entry points.
- Rename `PROP_ENTITY_SIZE_LIMIT` to `PROP_TOTAL_ENTITY_SIZE_LIMIT` so the constants name the properties they hold, and replace the magic `"0"` with a documented `NO_LIMIT` constant.

The tools are fed trusted Wikipedia dumps whose entity sizes legitimately exceed the JDK defaults, so disabling the limits is intentional here — see https://docs.oracle.com/javase/tutorial/jaxp/limits/limits.html.

Verified with `mvn -pl dkpro-jwpl-datamachine,dkpro-jwpl-timemachine -am clean verify -Ptest-e2e-tools -Pcheckstyle` — the DataMachine and TimeMachine E2E tests pass.