### PR TITLE
Do not query for a unique result where PageMapLine holds several entries

### DIFF
--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Wikipedia.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Wikipedia.java
@@ -194,12 +194,22 @@ public class Wikipedia
      * @throws WikiApiException Thrown if errors occurred.
      */
     public Title getTitle(int pageId) throws WikiApiException {
+        // Read from Page, not from PageMapLine, the way getTitles(Collection) does. A page id is
+        // unique in Page, while PageMapLine holds one entry per title the id can be reached by - the
+        // name of the page itself and the name of every redirect pointing to it. Asking PageMapLine
+        // for a unique result therefore failed for every page that has a redirect, and it could not
+        // tell the name of the page from the name of a redirect to begin with.
+        String returnValue;
         Session session = this.__getHibernateSession();
-        session.beginTransaction();
-        String sql = "select p.name from PageMapLine as p where p.pageId= :pId";
-        String returnValue = session.createNativeQuery(sql, String.class)
-                .setParameter("pId", pageId, StandardBasicTypes.INTEGER).uniqueResult();
-        session.getTransaction().commit();
+        try {
+            session.beginTransaction();
+            String sql = "select p.name from Page as p where p.pageId = :pId";
+            returnValue = session.createQuery(sql, String.class).setParameter("pId", pageId)
+                    .uniqueResult();
+        }
+        finally {
+            session.getTransaction().commit();
+        }
 
         if (returnValue == null) {
             throw new WikiPageNotFoundException();
@@ -765,8 +775,15 @@ public class Wikipedia
 
             // Eclipse somehow thinks that setParameter returns a MutationQuery instead of a
             // NativeQuery...
+            // A name is not unique in PageMapLine: case variants of one title map to their own
+            // entry, and a database whose charset cannot represent a title stores the substituted
+            // characters, which lets unrelated titles collapse onto one name. Asking for a unique
+            // result made this method throw NonUniqueResultException - unchecked, and out of a
+            // method that promises a boolean instead of an exception. One entry is all it takes to
+            // answer the question.
             var nativeQuery = session.createNativeQuery(query, Long.class)
-                    .setParameter("pName", encodedTitle, StandardBasicTypes.STRING);
+                    .setParameter("pName", encodedTitle, StandardBasicTypes.STRING)
+                    .setMaxResults(1);
             var returnValue = nativeQuery.uniqueResult();
             return returnValue != null;
         } finally {
@@ -791,13 +808,21 @@ public class Wikipedia
         }
 
         Session session = this.__getHibernateSession();
-        session.beginTransaction();
-        String sql = "select p.id from PageMapLine as p where p.pageID = :pageId";
-        Long returnValue = session.createNativeQuery(sql, Long.class)
-                .setParameter("pageId", pageID, StandardBasicTypes.INTEGER).uniqueResult();
-        session.getTransaction().commit();
+        try {
+            session.beginTransaction();
+            // PageMapLine holds one entry per title the page id can be reached by, so a page that
+            // has redirects carries several of them. One entry answers the question, see
+            // existsPage(String) on why a unique result must not be asked for here.
+            String sql = "select p.id from PageMapLine as p where p.pageID = :pageId";
+            Long returnValue = session.createNativeQuery(sql, Long.class)
+                    .setParameter("pageId", pageID, StandardBasicTypes.INTEGER).setMaxResults(1)
+                    .uniqueResult();
 
-        return returnValue != null;
+            return returnValue != null;
+        }
+        finally {
+            session.getTransaction().commit();
+        }
     }
 
     /**

--- a/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/TitleIteratorTest.java
+++ b/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/TitleIteratorTest.java
@@ -56,7 +56,7 @@ public class TitleIteratorTest
             assertNotNull(t);
             nrOfTitles++;
         }
-        assertEquals(40, nrOfTitles, "Number of titles == 40");
+        assertEquals(42, nrOfTitles, "Number of titles == 42");
 
     }
 }

--- a/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/WikipediaTest.java
+++ b/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/WikipediaTest.java
@@ -54,6 +54,13 @@ public class WikipediaTest
     private static final String A_FAMOUS_PAGE_CLEAN = "Exploring the Potential of Semantic Relatedness in Information Retrieval";
     private static final int A_FAMOUS_PAGE_ID = 1017;
 
+    /** A page that redirects point to, hence one holding more than one entry in {@code PageMapLine}. */
+    private static final String A_PAGE_WITH_REDIRECTS = "Net_Centric_Systems";
+    private static final int A_PAGE_WITH_REDIRECTS_ID = 101;
+
+    /** A name that more than one entry of {@code PageMapLine} carries. */
+    private static final String A_DUPLICATE_TITLE = "Ambiguous_Title";
+
     /**
      * Made this static so that following tests don't run if assumption fails. (With AT_Before,
      * tests also would not be executed but marked as passed) This could be changed back as soon as
@@ -250,6 +257,41 @@ public class WikipediaTest
     {
         assertFalse(wiki.existsPage(null));
         assertFalse(wiki.existsPage(""));
+    }
+
+    /**
+     * A page and every redirect pointing to it share one entry per title in {@code PageMapLine}, all
+     * of them carrying the page id of the page. Looking that id up must not depend on the page having
+     * no redirects.
+     */
+    @Test
+    public void testExistsPageByIdOfPageWithRedirects()
+    {
+        assertTrue(wiki.existsPage(A_PAGE_WITH_REDIRECTS_ID));
+    }
+
+    /**
+     * The title of a page is the name of the page itself, not one of the titles redirecting to it.
+     *
+     * @see #testExistsPageByIdOfPageWithRedirects()
+     */
+    @Test
+    public void testGetTitleByIdOfPageWithRedirects() throws WikiApiException
+    {
+        Title title = wiki.getTitle(A_PAGE_WITH_REDIRECTS_ID);
+        assertNotNull(title);
+        assertEquals(A_PAGE_WITH_REDIRECTS, title.getRawTitleText());
+    }
+
+    /**
+     * A name is not unique in {@code PageMapLine}, see the entries of {@link #A_DUPLICATE_TITLE} in the
+     * test data. Existence is a question about the presence of an entry, so more than one of them is
+     * an answer, not an error.
+     */
+    @Test
+    public void testExistsPageByTitleThatOccursMoreThanOnce()
+    {
+        assertTrue(wiki.existsPage(A_DUPLICATE_TITLE));
     }
 
     @Test

--- a/dkpro-jwpl-api/src/test/resources/db/data.sql
+++ b/dkpro-jwpl-api/src/test/resources/db/data.sql
@@ -125,6 +125,11 @@ INSERT INTO PageMapLine VALUES (37, 'Discussion:Wikipedia_API', 4000, NULL, NULL
 INSERT INTO PageMapLine VALUES (38, 'Humanbiologie', 6000, NULL, NULL);
 INSERT INTO PageMapLine VALUES (39, 'Liste_von_Materia_Medica_der_traditionellen_uigurischen_Medizin', 6001, NULL, NULL);
 INSERT INTO PageMapLine VALUES (40, 'Moore''s_law', 6002, NULL, NULL);
+-- Two entries share one name on purpose. A name is not unique in PageMapLine: case variants of the
+-- same title map to their own entry, and a database whose charset cannot represent a title stores
+-- the substituted characters, which lets unrelated titles collapse onto one name.
+INSERT INTO PageMapLine VALUES (41, 'Ambiguous_Title', 101, NULL, NULL);
+INSERT INTO PageMapLine VALUES (42, 'Ambiguous_Title', 1017, NULL, NULL);
 
 INSERT INTO category_inlinks VALUES (2, 8);
 INSERT INTO category_inlinks VALUES (3, 1);


### PR DESCRIPTION
**What's in the PR**

`PageMapLine` maps every title a page can be reached by to that page: the name of the page itself and the name of every redirect pointing to it. A name is not unique there either — case variants of one title get their own entry, and a database whose charset cannot represent a title stores the substituted characters, which lets unrelated titles collapse onto one name.

Three lookups asked for a unique result nevertheless and threw `NonUniqueResultException`. It is unchecked, so it reaches callers that have no way to see it coming — none of the three methods declares it, and `existsPage(..)` explicitly promises a boolean *instead of* an exception.

* `existsPage(int)` — fails for **every page that has a redirect**. On a current German snapshot that is 1,064,568 of the 5,142,247 `PageMapLine` entries.
* `getTitle(int)` — fails for the same pages, and could not tell the name of the page from the name of a redirect to begin with.
* `existsPage(String)` — fails for a name carried by more than one entry.

The two lookups by id left their transaction open on top, so after the first failure every later call on the same thread failed with `Transaction already active` for an entirely unrelated reason. The existing test suite shows this nicely: the added fixture makes one lookup throw, and 26 of the 49 `WikipediaTest` cases then fall over behind it.

**The change**

* `existsPage(int)` and `existsPage(String)` read one entry — all the question needs — and commit in a `finally`.
* `getTitle(int)` reads from `Page` the way `getTitles(Collection)` already does. A page id is unique there, and the name is the name of the page rather than an arbitrary one of its redirects. For a page without redirects the result is unchanged, since its single `PageMapLine` entry carries exactly that name.

`Page.getPageId(Title, boolean)` already guards the same lookup with `LIMIT 1`, and its comment already describes several entries sharing one name, so this brings the rest of the API in line with it.

**How to test manually**

Against any JWPL database, `getTitle(id)` and `existsPage(id)` of a page that has at least one redirect threw `NonUniqueResultException` before and return the page title respectively `true` now.

**Automatic testing**

* [x] PR includes unit tests

`WikipediaTest` gains three cases — existence and title of a page reachable by more than one title, and existence of a name carried by more than one entry. The test data gains two entries sharing one name for the last of them (`TitleIteratorTest` counts titles, hence 40 -> 42); the page with redirects was already in there and simply had no test.

All 260 tests of `dkpro-jwpl-api` pass, and so does the full reactor.

**Documentation**

* [ ] PR updates documentation
