### PR TITLE
Fix resource leaks in the API and the tooling

### DIFF
--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Category.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Category.java
@@ -25,7 +25,6 @@ import org.dkpro.jwpl.api.exception.WikiPageNotFoundException;
 import org.dkpro.jwpl.api.exception.WikiTitleParsingException;
 import org.dkpro.jwpl.api.hibernate.CategoryDAO;
 import org.hibernate.LockMode;
-import org.hibernate.Session;
 import org.hibernate.type.StandardBasicTypes;
 
 /**
@@ -106,10 +105,7 @@ public class Category
      */
     private void createCategory(long id) throws WikiPageNotFoundException
     {
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
-        hibernateCategory = catDAO.findById(id);
-        session.getTransaction().commit();
+        hibernateCategory = wiki.__inTransaction(session -> catDAO.findById(id));
 
         if (hibernateCategory == null) {
             throw new WikiPageNotFoundException("No category with id " + id + " was found.");
@@ -130,18 +126,13 @@ public class Category
     private void createCategory(Title title) throws WikiPageNotFoundException
     {
         String name = title.getWikiStyleTitle();
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
 
-        Integer returnValue;
-
-        String query = "select cat.pageId from Category as cat where cat.name = :name";
-        if (wiki.getDatabaseConfiguration().supportsCollation()) {
-            query += Wikipedia.SQL_COLLATION;
-        }
-        returnValue = session.createNativeQuery(query, Integer.class)
-                .setParameter("name", name, StandardBasicTypes.STRING).uniqueResult();
-        session.getTransaction().commit();
+        final String query = "select cat.pageId from Category as cat where cat.name = :name"
+                + (wiki.getDatabaseConfiguration().supportsCollation() ? Wikipedia.SQL_COLLATION
+                        : "");
+        Integer returnValue = wiki.__inTransaction(
+                session -> session.createNativeQuery(query, Integer.class)
+                        .setParameter("name", name, StandardBasicTypes.STRING).uniqueResult());
 
         // if there is no category with this name, the hibernateCategory is null
         if (returnValue == null) {
@@ -165,12 +156,10 @@ public class Category
      */
     long __getId()
     {
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
-        session.lock(hibernateCategory, LockMode.NONE);
-        long id = hibernateCategory.getId();
-        session.getTransaction().commit();
-        return id;
+        return wiki.__inTransaction(session -> {
+            session.lock(hibernateCategory, LockMode.NONE);
+            return hibernateCategory.getId();
+        });
     }
 
     /**
@@ -178,12 +167,10 @@ public class Category
      */
     public int getPageId()
     {
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
-        session.lock(hibernateCategory, LockMode.NONE);
-        int pageID = hibernateCategory.getPageId();
-        session.getTransaction().commit();
-        return pageID;
+        return wiki.__inTransaction(session -> {
+            session.lock(hibernateCategory, LockMode.NONE);
+            return hibernateCategory.getPageId();
+        });
     }
 
     /**
@@ -191,11 +178,10 @@ public class Category
      */
     public Set<Category> getParents()
     {
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
-        session.lock(hibernateCategory, LockMode.NONE);
-        Set<Integer> tmpSet = new HashSet<>(hibernateCategory.getInLinks());
-        session.getTransaction().commit();
+        Set<Integer> tmpSet = wiki.__inTransaction(session -> {
+            session.lock(hibernateCategory, LockMode.NONE);
+            return new HashSet<>(hibernateCategory.getInLinks());
+        });
 
         Set<Category> categories = new HashSet<>();
         for (int pageID : tmpSet) {
@@ -215,12 +201,10 @@ public class Category
         int nrOfInlinks = 0;
 
         long id = this.__getId();
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
         String sql = "select count(inLinks) from category_inlinks where id = :id";
-        Long returnValue = session.createNativeQuery(sql, Long.class)
-                .setParameter("id", id, StandardBasicTypes.LONG).uniqueResult();
-        session.getTransaction().commit();
+        Long returnValue = wiki.__inTransaction(session -> session
+                .createNativeQuery(sql, Long.class)
+                .setParameter("id", id, StandardBasicTypes.LONG).uniqueResult());
 
         if (returnValue != null) {
             nrOfInlinks = returnValue.intValue();
@@ -233,12 +217,10 @@ public class Category
      */
     public Set<Integer> getParentIDs()
     {
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
-        session.lock(hibernateCategory, LockMode.NONE);
-        Set<Integer> tmpSet = new HashSet<>(hibernateCategory.getInLinks());
-        session.getTransaction().commit();
-        return tmpSet;
+        return wiki.__inTransaction(session -> {
+            session.lock(hibernateCategory, LockMode.NONE);
+            return new HashSet<>(hibernateCategory.getInLinks());
+        });
     }
 
     /**
@@ -246,11 +228,10 @@ public class Category
      */
     public Set<Category> getChildren()
     {
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
-        session.lock(hibernateCategory, LockMode.NONE);
-        Set<Integer> tmpSet = new HashSet<>(hibernateCategory.getOutLinks());
-        session.getTransaction().commit();
+        Set<Integer> tmpSet = wiki.__inTransaction(session -> {
+            session.lock(hibernateCategory, LockMode.NONE);
+            return new HashSet<>(hibernateCategory.getOutLinks());
+        });
 
         Set<Category> categories = new HashSet<>();
         for (int pageID : tmpSet) {
@@ -270,12 +251,10 @@ public class Category
         int nrOfOutlinks = 0;
 
         long id = this.__getId();
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
         String sql = "select count(outLinks) from category_outlinks where id = :id";
-        Long returnValue = session.createNativeQuery(sql, Long.class)
-                .setParameter("id", id, StandardBasicTypes.LONG).uniqueResult();
-        session.getTransaction().commit();
+        Long returnValue = wiki.__inTransaction(session -> session
+                .createNativeQuery(sql, Long.class)
+                .setParameter("id", id, StandardBasicTypes.LONG).uniqueResult());
 
         if (returnValue != null) {
             nrOfOutlinks = returnValue.intValue();
@@ -288,12 +267,10 @@ public class Category
      */
     public Set<Integer> getChildrenIDs()
     {
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
-        session.lock(hibernateCategory, LockMode.NONE);
-        Set<Integer> tmpSet = new HashSet<>(hibernateCategory.getOutLinks());
-        session.getTransaction().commit();
-        return tmpSet;
+        return wiki.__inTransaction(session -> {
+            session.lock(hibernateCategory, LockMode.NONE);
+            return new HashSet<>(hibernateCategory.getOutLinks());
+        });
     }
 
     /**
@@ -303,11 +280,10 @@ public class Category
      */
     public Title getTitle() throws WikiTitleParsingException
     {
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
-        session.lock(hibernateCategory, LockMode.NONE);
-        String name = hibernateCategory.getName();
-        session.getTransaction().commit();
+        String name = wiki.__inTransaction(session -> {
+            session.lock(hibernateCategory, LockMode.NONE);
+            return hibernateCategory.getName();
+        });
         return new Title(name);
     }
 
@@ -331,13 +307,10 @@ public class Category
      */
     public Set<Integer> getArticleIds()
     {
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
-        session.lock(hibernateCategory, LockMode.NONE);
-        Set<Integer> tmpSet = new HashSet<>(hibernateCategory.getPages());
-        session.getTransaction().commit();
-
-        return tmpSet;
+        return wiki.__inTransaction(session -> {
+            session.lock(hibernateCategory, LockMode.NONE);
+            return new HashSet<>(hibernateCategory.getPages());
+        });
     }
 
     /**
@@ -351,12 +324,10 @@ public class Category
         int nrOfPages = 0;
 
         long id = this.__getId();
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
         String sql = "select count(pages) from category_pages where id = :id";
-        Long returnValue = session.createNativeQuery(sql, Long.class)
-                .setParameter("id", id, StandardBasicTypes.LONG).uniqueResult();
-        session.getTransaction().commit();
+        Long returnValue = wiki.__inTransaction(session -> session
+                .createNativeQuery(sql, Long.class)
+                .setParameter("id", id, StandardBasicTypes.LONG).uniqueResult());
 
         if (returnValue != null) {
             nrOfPages = returnValue.intValue();

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/CategoryIterator.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/CategoryIterator.java
@@ -23,7 +23,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.dkpro.jwpl.api.exception.WikiApiException;
-import org.hibernate.Session;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -141,14 +140,12 @@ public class CategoryIterator
         private boolean fillBuffer()
         {
 
-            Session session = this.wiki.__getHibernateSession();
-            session.beginTransaction();
             final String sql = "SELECT c FROM Category c";
-            List<org.dkpro.jwpl.api.hibernate.Category> returnValues = session
-                    .createQuery(sql, org.dkpro.jwpl.api.hibernate.Category.class)
-                    .setFirstResult(dataOffset).setMaxResults(maxBufferSize)
-                    .setFetchSize(maxBufferSize).list();
-            session.getTransaction().commit();
+            List<org.dkpro.jwpl.api.hibernate.Category> returnValues = wiki.__inTransaction(
+                    session -> session
+                            .createQuery(sql, org.dkpro.jwpl.api.hibernate.Category.class)
+                            .setFirstResult(dataOffset).setMaxResults(maxBufferSize)
+                            .setFetchSize(maxBufferSize).list());
 
             // clear the old buffer and all variables regarding the state of the buffer
             buffer.clear();

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/MetaData.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/MetaData.java
@@ -52,10 +52,7 @@ public class MetaData
          */
         Class<? extends AbstractMetaData> entityClass = WikiHibernateUtil
                 .getMetaDataEntityClass(wiki.getDatabaseConfiguration());
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
-        hibernateMetaData = loadMetaData(session, entityClass);
-        session.getTransaction().commit();
+        hibernateMetaData = wiki.__inTransaction(session -> loadMetaData(session, entityClass));
     }
 
     private static <T extends AbstractMetaData> T loadMetaData(Session session, Class<T> type)
@@ -74,12 +71,10 @@ public class MetaData
      */
     long getId()
     {
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
-        session.lock(hibernateMetaData, LockMode.NONE);
-        long id = hibernateMetaData.getId();
-        session.getTransaction().commit();
-        return id;
+        return wiki.__inTransaction(session -> {
+            session.lock(hibernateMetaData, LockMode.NONE);
+            return hibernateMetaData.getId();
+        });
     }
 
     /**
@@ -87,12 +82,10 @@ public class MetaData
      */
     public long getNumberOfCategories()
     {
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
-        session.lock(hibernateMetaData, LockMode.NONE);
-        long nrofCategories = hibernateMetaData.getNrofCategories();
-        session.getTransaction().commit();
-        return nrofCategories;
+        return wiki.__inTransaction(session -> {
+            session.lock(hibernateMetaData, LockMode.NONE);
+            return hibernateMetaData.getNrofCategories();
+        });
     }
 
     /**
@@ -100,12 +93,10 @@ public class MetaData
      */
     public long getNumberOfPages()
     {
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
-        session.lock(hibernateMetaData, LockMode.NONE);
-        long nrofPages = hibernateMetaData.getNrofPages();
-        session.getTransaction().commit();
-        return nrofPages;
+        return wiki.__inTransaction(session -> {
+            session.lock(hibernateMetaData, LockMode.NONE);
+            return hibernateMetaData.getNrofPages();
+        });
     }
 
     /**
@@ -113,12 +104,10 @@ public class MetaData
      */
     public long getNumberOfDisambiguationPages()
     {
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
-        session.lock(hibernateMetaData, LockMode.NONE);
-        long nrofDisambPages = hibernateMetaData.getNrofDisambiguationPages();
-        session.getTransaction().commit();
-        return nrofDisambPages;
+        return wiki.__inTransaction(session -> {
+            session.lock(hibernateMetaData, LockMode.NONE);
+            return hibernateMetaData.getNrofDisambiguationPages();
+        });
     }
 
     /**
@@ -126,12 +115,10 @@ public class MetaData
      */
     public long getNumberOfRedirectPages()
     {
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
-        session.lock(hibernateMetaData, LockMode.NONE);
-        long nrofRedirects = hibernateMetaData.getNrofRedirects();
-        session.getTransaction().commit();
-        return nrofRedirects;
+        return wiki.__inTransaction(session -> {
+            session.lock(hibernateMetaData, LockMode.NONE);
+            return hibernateMetaData.getNrofRedirects();
+        });
     }
 
     /**
@@ -141,11 +128,10 @@ public class MetaData
      */
     public Category getDisambiguationCategory() throws WikiApiException
     {
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
-        session.lock(hibernateMetaData, LockMode.NONE);
-        String disambCategoryTitle = hibernateMetaData.getDisambiguationCategory();
-        session.getTransaction().commit();
+        String disambCategoryTitle = wiki.__inTransaction(session -> {
+            session.lock(hibernateMetaData, LockMode.NONE);
+            return hibernateMetaData.getDisambiguationCategory();
+        });
         return wiki.getCategory(disambCategoryTitle);
     }
 
@@ -156,11 +142,10 @@ public class MetaData
      */
     public Category getMainCategory() throws WikiApiException
     {
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
-        session.lock(hibernateMetaData, LockMode.NONE);
-        String mainCategoryTitle = hibernateMetaData.getMainCategory();
-        session.getTransaction().commit();
+        String mainCategoryTitle = wiki.__inTransaction(session -> {
+            session.lock(hibernateMetaData, LockMode.NONE);
+            return hibernateMetaData.getMainCategory();
+        });
         return wiki.getCategory(mainCategoryTitle);
     }
 
@@ -176,12 +161,10 @@ public class MetaData
      */
     public String getVersion() throws WikiApiException
     {
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
-        session.lock(hibernateMetaData, LockMode.NONE);
-        String version = hibernateMetaData.getVersion();
-        session.getTransaction().commit();
-        return version;
+        return wiki.__inTransaction(session -> {
+            session.lock(hibernateMetaData, LockMode.NONE);
+            return hibernateMetaData.getVersion();
+        });
     }
 
     /**

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Page.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Page.java
@@ -27,7 +27,6 @@ import org.dkpro.jwpl.api.hibernate.PageDAO;
 import org.dkpro.jwpl.api.sweble.PlainTextConverter;
 import org.dkpro.jwpl.api.util.UnmodifiableArraySet;
 import org.hibernate.LockOptions;
-import org.hibernate.Session;
 import org.hibernate.type.StandardBasicTypes;
 import org.sweble.wikitext.engine.PageId;
 import org.sweble.wikitext.engine.PageTitle;
@@ -159,10 +158,7 @@ public class Page
      */
     private void fetchByHibernateId(long id) throws WikiApiException
     {
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
-        hibernatePage = pageDAO.findById(id);
-        session.getTransaction().commit();
+        hibernatePage = wiki.__inTransaction(session -> pageDAO.findById(id));
 
         if (hibernatePage == null) {
             throw new WikiPageNotFoundException("No page with id " + id + " was found.");
@@ -171,13 +167,10 @@ public class Page
 
     private void fetchByPageId(int pageID) throws WikiApiException
     {
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
-        hibernatePage = session
+        hibernatePage = wiki.__inTransaction(session -> session
                 .createQuery("from Page where pageId = :id",
                         org.dkpro.jwpl.api.hibernate.Page.class)
-                .setParameter("id", pageID, StandardBasicTypes.INTEGER).uniqueResult();
-        session.getTransaction().commit();
+                .setParameter("id", pageID, StandardBasicTypes.INTEGER).uniqueResult());
 
         if (hibernatePage == null) {
             throw new WikiPageNotFoundException("No page with page id " + pageID + " was found.");
@@ -193,18 +186,14 @@ public class Page
      */
     private void fetchByTitle(Title pTitle, boolean useExactTitle) throws WikiApiException
     {
-        String searchString = pTitle.getPlainTitle();
-        if (!useExactTitle) {
-            searchString = pTitle.getWikiStyleTitle();
-        }
+        final String searchString = useExactTitle ? pTitle.getPlainTitle()
+                : pTitle.getWikiStyleTitle();
 
-        Session session;
-        session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
         String sql = "select pml.pageID from PageMapLine as pml where pml.name = :pagetitle LIMIT 1";
-        Integer pageId = session.createNativeQuery(sql, Integer.class)
-                .setParameter("pagetitle", searchString, StandardBasicTypes.STRING).uniqueResult();
-        session.getTransaction().commit();
+        Integer pageId = wiki.__inTransaction(
+                session -> session.createNativeQuery(sql, Integer.class)
+                        .setParameter("pagetitle", searchString, StandardBasicTypes.STRING)
+                        .uniqueResult());
 
         if (pageId == null) {
             throw new WikiPageNotFoundException(
@@ -279,11 +268,10 @@ public class Page
      */
     public Set<Category> getCategories()
     {
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
-        session.lock(hibernatePage, LockOptions.NONE);
-        Set<Integer> tmp = new UnmodifiableArraySet<>(hibernatePage.getCategories());
-        session.getTransaction().commit();
+        Set<Integer> tmp = wiki.__inTransaction(session -> {
+            session.lock(hibernatePage, LockOptions.NONE);
+            return new UnmodifiableArraySet<>(hibernatePage.getCategories());
+        });
 
         Set<Category> categories = new HashSet<>();
         for (int pageID : tmp) {
@@ -304,12 +292,10 @@ public class Page
         int nrOfCategories = 0;
 
         long id = __getId();
-        Session session = wiki.__getHibernateSession();
-        session.beginTransaction();
         String sql = "select count(pages) from page_categories where id = :pageid";
-        Long returnValue = session.createNativeQuery(sql, Long.class)
-                .setParameter("pageid", id, StandardBasicTypes.LONG).uniqueResult();
-        session.getTransaction().commit();
+        Long returnValue = wiki.__inTransaction(session -> session
+                .createNativeQuery(sql, Long.class)
+                .setParameter("pageid", id, StandardBasicTypes.LONG).uniqueResult());
 
         if (returnValue != null) {
             nrOfCategories = returnValue.intValue();
@@ -328,12 +314,11 @@ public class Page
      */
     public Set<Page> getInlinks()
     {
-        Session session = wiki.__getHibernateSession();
-        session.beginTransaction();
-        session.lock(hibernatePage, LockOptions.NONE);
         // Have to copy links here since getPage later will close the session.
-        Set<Integer> pageIDs = new UnmodifiableArraySet<>(hibernatePage.getInLinks());
-        session.getTransaction().commit();
+        Set<Integer> pageIDs = wiki.__inTransaction(session -> {
+            session.lock(hibernatePage, LockOptions.NONE);
+            return new UnmodifiableArraySet<>(hibernatePage.getInLinks());
+        });
 
         Set<Page> pages = new HashSet<>();
         for (int pageID : pageIDs) {
@@ -360,12 +345,10 @@ public class Page
         int nrOfInlinks = 0;
 
         long id = __getId();
-        Session session = wiki.__getHibernateSession();
-        session.beginTransaction();
         String sql = "select count(pi.inLinks) from page_inlinks as pi where pi.id = :piid";
-        Long returnValue = session.createNativeQuery(sql, Long.class)
-                .setParameter("piid", id, StandardBasicTypes.LONG).uniqueResult();
-        session.getTransaction().commit();
+        Long returnValue = wiki.__inTransaction(session -> session
+                .createNativeQuery(sql, Long.class)
+                .setParameter("piid", id, StandardBasicTypes.LONG).uniqueResult());
 
         if (returnValue != null) {
             nrOfInlinks = returnValue.intValue();
@@ -381,14 +364,10 @@ public class Page
      */
     public Set<Integer> getInlinkIDs()
     {
-        Session session = wiki.__getHibernateSession();
-        session.beginTransaction();
-        session.lock(hibernatePage, LockOptions.NONE);
-
-        Set<Integer> tmpSet = new HashSet<>(hibernatePage.getInLinks());
-
-        session.getTransaction().commit();
-        return tmpSet;
+        return wiki.__inTransaction(session -> {
+            session.lock(hibernatePage, LockOptions.NONE);
+            return new HashSet<>(hibernatePage.getInLinks());
+        });
     }
 
     /**
@@ -416,13 +395,11 @@ public class Page
      */
     public Set<Page> getOutlinks()
     {
-        Session session = wiki.__getHibernateSession();
-        session.beginTransaction();
-        // session.lock(hibernatePage, LockMode.NONE);
-        session.lock(hibernatePage, LockOptions.NONE);
         // Have to copy links here since getPage later will close the session.
-        Set<Integer> tmpSet = new UnmodifiableArraySet<>(hibernatePage.getOutLinks());
-        session.getTransaction().commit();
+        Set<Integer> tmpSet = wiki.__inTransaction(session -> {
+            session.lock(hibernatePage, LockOptions.NONE);
+            return new UnmodifiableArraySet<>(hibernatePage.getOutLinks());
+        });
 
         Set<Page> pages = new HashSet<>();
         for (int pageID : tmpSet) {
@@ -448,12 +425,10 @@ public class Page
         int nrOfOutlinks = 0;
 
         long id = __getId();
-        Session session = wiki.__getHibernateSession();
-        session.beginTransaction();
         String sql = "select count(outLinks) from page_outlinks where id = :id";
-        Long returnValue = session.createNativeQuery(sql, Long.class)
-                .setParameter("id", id, StandardBasicTypes.LONG).uniqueResult();
-        session.getTransaction().commit();
+        Long returnValue = wiki.__inTransaction(session -> session
+                .createNativeQuery(sql, Long.class)
+                .setParameter("id", id, StandardBasicTypes.LONG).uniqueResult());
 
         if (returnValue != null) {
             nrOfOutlinks = returnValue.intValue();
@@ -470,14 +445,10 @@ public class Page
     public Set<Integer> getOutlinkIDs()
     {
 
-        Session session = wiki.__getHibernateSession();
-        session.beginTransaction();
-        session.lock(hibernatePage, LockOptions.NONE);
-
-        Set<Integer> tmpSet = new HashSet<>(hibernatePage.getOutLinks());
-
-        session.getTransaction().commit();
-        return tmpSet;
+        return wiki.__inTransaction(session -> {
+            session.lock(hibernatePage, LockOptions.NONE);
+            return new HashSet<>(hibernatePage.getOutLinks());
+        });
     }
 
     /**
@@ -502,10 +473,7 @@ public class Page
      */
     public Title getTitle() throws WikiTitleParsingException
     {
-        Session session = wiki.__getHibernateSession();
-        session.beginTransaction();
-        String name = hibernatePage.getName();
-        session.getTransaction().commit();
+        String name = wiki.__inTransaction(session -> hibernatePage.getName());
         return new Title(name);
     }
 
@@ -514,12 +482,10 @@ public class Page
      */
     public Set<String> getRedirects()
     {
-        Session session = wiki.__getHibernateSession();
-        session.beginTransaction();
-        session.lock(hibernatePage, LockOptions.NONE);
-        Set<String> tmpSet = new HashSet<>(hibernatePage.getRedirects());
-        session.getTransaction().commit();
-        return tmpSet;
+        return wiki.__inTransaction(session -> {
+            session.lock(hibernatePage, LockOptions.NONE);
+            return new HashSet<>(hibernatePage.getRedirects());
+        });
     }
 
     /**
@@ -527,10 +493,7 @@ public class Page
      */
     public String getText()
     {
-        Session session = wiki.__getHibernateSession();
-        session.beginTransaction();
-        String text = hibernatePage.getText();
-        session.getTransaction().commit();
+        String text = wiki.__inTransaction(session -> hibernatePage.getText());
 
         // Normalize strings read from the DB to use "\n" for all line breaks.
         StringBuilder sb = new StringBuilder(text);
@@ -571,11 +534,7 @@ public class Page
      */
     public boolean isDisambiguation()
     {
-        Session session = wiki.__getHibernateSession();
-        session.beginTransaction();
-        boolean isDisambiguation = hibernatePage.getIsDisambiguation();
-        session.getTransaction().commit();
-        return isDisambiguation;
+        return wiki.__inTransaction(session -> hibernatePage.getIsDisambiguation());
     }
 
     /**

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/PageIterator.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/PageIterator.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.dkpro.jwpl.api.exception.WikiApiException;
-import org.hibernate.Session;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -229,25 +228,26 @@ public class PageIterator
                 }
             }
             else {
-                Session session = this.wiki.__getHibernateSession();
-                session.beginTransaction();
-                List<org.dkpro.jwpl.api.hibernate.Page> returnValues;
-                TypedQuery<org.dkpro.jwpl.api.hibernate.Page> query;
-                String sql;
-                if (onlyArticles) {
-                    sql = "SELECT p FROM Page p WHERE p.isDisambiguation = :isDisambiguation AND p.id > :pageId";
-                    query = session.createQuery(sql, org.dkpro.jwpl.api.hibernate.Page.class);
-                    query.setParameter("isDisambiguation", false);
-                    query.setParameter("pageId", lastPage);
-                }
-                else {
-                    sql = "SELECT p FROM Page p WHERE p.id > :pageId";
-                    query = session.createQuery(sql, org.dkpro.jwpl.api.hibernate.Page.class);
-                    query.setParameter("pageId", lastPage);
-                }
-                query.setMaxResults(maxBufferSize);
-                returnValues = query.getResultList();
-                session.getTransaction().commit();
+                List<org.dkpro.jwpl.api.hibernate.Page> returnValues = wiki
+                        .__inTransaction(session -> {
+                            TypedQuery<org.dkpro.jwpl.api.hibernate.Page> query;
+                            String sql;
+                            if (onlyArticles) {
+                                sql = "SELECT p FROM Page p WHERE p.isDisambiguation = :isDisambiguation AND p.id > :pageId";
+                                query = session.createQuery(sql,
+                                        org.dkpro.jwpl.api.hibernate.Page.class);
+                                query.setParameter("isDisambiguation", false);
+                                query.setParameter("pageId", lastPage);
+                            }
+                            else {
+                                sql = "SELECT p FROM Page p WHERE p.id > :pageId";
+                                query = session.createQuery(sql,
+                                        org.dkpro.jwpl.api.hibernate.Page.class);
+                                query.setParameter("pageId", lastPage);
+                            }
+                            query.setMaxResults(maxBufferSize);
+                            return query.getResultList();
+                        });
 
                 // clear the old buffer and all variables regarding the state of the buffer
                 buffer.clear();

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/PageQueryIterable.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/PageQueryIterable.java
@@ -26,7 +26,6 @@ import org.dkpro.jwpl.api.exception.WikiApiException;
 import org.dkpro.jwpl.api.exception.WikiPageNotFoundException;
 import org.dkpro.jwpl.api.util.ApiUtilities;
 import org.dkpro.jwpl.api.util.StringUtils;
-import org.hibernate.Session;
 import org.hibernate.query.Query;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,14 +77,15 @@ public class PageQueryIterable
             hql += "where " + conditionString;
         }
 
-        Session session = this.wiki.__getHibernateSession();
-        session.beginTransaction();
-        Query<Integer> query = session.createQuery(hql, Integer.class);
-        if (hasTitlePattern) {
-            query.setParameter("name", q.getTitlePattern());
-        }
-        List<Integer> idList = query.list();
-        session.getTransaction().commit();
+        final String finalHql = hql;
+        final boolean titlePattern = hasTitlePattern;
+        List<Integer> idList = wiki.__inTransaction(session -> {
+            Query<Integer> query = session.createQuery(finalHql, Integer.class);
+            if (titlePattern) {
+                query.setParameter("name", q.getTitlePattern());
+            }
+            return query.list();
+        });
 
         int progress = 0;
         for (Integer pageID : idList) {

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/TitleIterator.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/TitleIterator.java
@@ -23,7 +23,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.dkpro.jwpl.api.exception.WikiTitleParsingException;
-import org.hibernate.Session;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -147,13 +146,11 @@ public class TitleIterator
         private boolean fillBuffer()
         {
 
-            Session session = this.wiki.__getHibernateSession();
-            session.beginTransaction();
             final String sql = "select p.name from PageMapLine as p";
-            List<String> returnList = session.createNativeQuery(sql, String.class)
-                    .setFirstResult(dataOffset).setMaxResults(maxBufferSize)
-                    .setFetchSize(maxBufferSize).list();
-            session.getTransaction().commit();
+            List<String> returnList = wiki
+                    .__inTransaction(session -> session.createNativeQuery(sql, String.class)
+                            .setFirstResult(dataOffset).setMaxResults(maxBufferSize)
+                            .setFetchSize(maxBufferSize).list());
 
             // clear the old buffer and all variables regarding the state of the buffer
             titleStringBuffer.clear();

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Wikipedia.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Wikipedia.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Function;
 
 import org.dkpro.jwpl.api.exception.WikiApiException;
 import org.dkpro.jwpl.api.exception.WikiInitializationException;
@@ -199,17 +200,10 @@ public class Wikipedia
         // name of the page itself and the name of every redirect pointing to it. Asking PageMapLine
         // for a unique result therefore failed for every page that has a redirect, and it could not
         // tell the name of the page from the name of a redirect to begin with.
-        String returnValue;
-        Session session = this.__getHibernateSession();
-        try {
-            session.beginTransaction();
-            String sql = "select p.name from Page as p where p.pageId = :pId";
-            returnValue = session.createQuery(sql, String.class).setParameter("pId", pageId)
-                    .uniqueResult();
-        }
-        finally {
-            session.getTransaction().commit();
-        }
+        String sql = "select p.name from Page as p where p.pageId = :pId";
+        String returnValue = __inTransaction(
+                session -> session.createQuery(sql, String.class).setParameter("pId", pageId)
+                        .uniqueResult());
 
         if (returnValue == null) {
             throw new WikiPageNotFoundException();
@@ -240,27 +234,13 @@ public class Wikipedia
         List<Integer> ids = new ArrayList<>(pageIds);
         for (int from = 0; from < ids.size(); from += TITLE_BATCH_SIZE) {
             List<Integer> batch = ids.subList(from, Math.min(from + TITLE_BATCH_SIZE, ids.size()));
-            // Re-acquired per batch on purpose: the thread-bound session context unbinds and closes
-            // the session once its transaction completes, so it must not be reused across batches.
-            Session session = this.__getHibernateSession();
-            session.beginTransaction();
-            List<Object[]> rows;
-            try {
-                rows = session
-                        .createQuery(
-                                "select p.pageId, p.name from Page as p where p.pageId in (:ids)",
-                                Object[].class)
-                        .setParameterList("ids", batch).list();
-                session.getTransaction().commit();
-            } catch (RuntimeException e) {
-                // A transaction left open would poison the thread-bound session for every later
-                // call on this thread, so callers that log the failure and move on to the next
-                // page would fail from here on for an unrelated reason.
-                if (session.getTransaction().isActive()) {
-                    session.getTransaction().rollback();
-                }
-                throw e;
-            }
+            // A session is acquired per batch on purpose: the thread-bound session context unbinds
+            // and closes the session once its transaction completes, so it must not be reused
+            // across batches.
+            List<Object[]> rows = __inTransaction(session -> session
+                    .createQuery("select p.pageId, p.name from Page as p where p.pageId in (:ids)",
+                            Object[].class)
+                    .setParameterList("ids", batch).list());
 
             for (Object[] row : rows) {
                 Integer pageId = (Integer) row[0];
@@ -286,13 +266,10 @@ public class Wikipedia
      * @throws WikiApiException Thrown if errors occurred.
      */
     public List<Integer> getPageIds(String title) throws WikiApiException {
-        Session session = this.__getHibernateSession();
-        session.beginTransaction();
         String sql = "select p.pageID from PageMapLine as p where p.name = :pName";
-        Iterator<Integer> results = session.createQuery(sql, Integer.class)
-                .setParameter("pName", title, StandardBasicTypes.STRING).list().iterator();
-
-        session.getTransaction().commit();
+        Iterator<Integer> results = __inTransaction(session -> session
+                .createQuery(sql, Integer.class)
+                .setParameter("pName", title, StandardBasicTypes.STRING).list()).iterator();
 
         if (!results.hasNext()) {
             throw new WikiPageNotFoundException();
@@ -312,16 +289,13 @@ public class Wikipedia
      * @throws WikiApiException Thrown if errors occurred.
      */
     public List<Integer> getPageIdsCaseInsensitive(String title) throws WikiApiException {
-        title = title.toLowerCase();
-        title = title.replaceAll(" ", "_");
+        final String normalizedTitle = title.toLowerCase().replaceAll(" ", "_");
 
-        Session session = this.__getHibernateSession();
-        session.beginTransaction();
         String sql = "select p.pageID from PageMapLine as p where lower(p.name) = :pName";
-        Iterator<Integer> results = session.createQuery(sql, Integer.class)
-                .setParameter("pName", title, StandardBasicTypes.STRING).list().iterator();
-
-        session.getTransaction().commit();
+        Iterator<Integer> results = __inTransaction(session -> session
+                .createQuery(sql, Integer.class)
+                .setParameter("pName", normalizedTitle, StandardBasicTypes.STRING).list())
+                .iterator();
 
         if (!results.hasNext()) {
             throw new WikiPageNotFoundException();
@@ -460,17 +434,13 @@ public class Wikipedia
             articleTitle = WikiConstants.DISCUSSION_PREFIX + articleTitle;
         }
 
-        Session session = this.__getHibernateSession();
-        session.beginTransaction();
-
         List<Page> discussionArchives = new LinkedList<>();
 
         String sql = "SELECT pageID FROM PageMapLine where name like :name";
-        Iterator<Integer> results = session.createQuery(sql, Integer.class)
-                .setParameter("name", articleTitle + "/%", StandardBasicTypes.STRING).list()
-                .iterator();
-
-        session.getTransaction().commit();
+        final String namePattern = articleTitle + "/%";
+        Iterator<Integer> results = __inTransaction(session -> session
+                .createQuery(sql, Integer.class)
+                .setParameter("name", namePattern, StandardBasicTypes.STRING).list()).iterator();
 
         while (results.hasNext()) {
             int pageID = results.next();
@@ -502,12 +472,12 @@ public class Wikipedia
         Map<Integer, Double> distanceMap = new HashMap<>();
 
         final LevenshteinStringDistance lsd = new LevenshteinStringDistance();
-        Session session = this.__getHibernateSession();
-        session.beginTransaction();
         final String query = "select new org.dkpro.jwpl.api.Wikipedia$PageTuple(pml.pageID, pml.name)"
                 + " from PageMapLine as pml";
-        for (PageTuple o : session.createQuery(query, PageTuple.class)
-                .list()) {
+        // The whole table is materialized by the query anyway, so the scoring below runs outside
+        // the transaction rather than holding a connection for its duration.
+        for (PageTuple o : __inTransaction(
+                session -> session.createQuery(query, PageTuple.class).list())) {
 
             // this returns a similarity - if we want to use it, we have to change the semantics the
             // ordering of the results
@@ -528,7 +498,6 @@ public class Wikipedia
                 }
             }
         }
-        session.getTransaction().commit();
 
         for (int pageID : distanceMap.keySet()) {
             Page page = null;
@@ -605,12 +574,9 @@ public class Wikipedia
             throw new WikiPageNotFoundException();
         }
 
-        Session session = this.__getHibernateSession();
-        session.beginTransaction();
         String sql = "select c from Page p left join p.categories c where p.name = :pageTitle";
-        List<Integer> categoryHibernateIds = session.createQuery(sql, Integer.class)
-                .setParameter("pageTitle", pageTitle).list();
-        session.getTransaction().commit();
+        List<Integer> categoryHibernateIds = __inTransaction(session -> session
+                .createQuery(sql, Integer.class).setParameter("pageTitle", pageTitle).list());
 
         Set<Category> categorySet = new HashSet<>(categoryHibernateIds.size());
         for (int hibernateId : categoryHibernateIds) {
@@ -644,11 +610,9 @@ public class Wikipedia
     // TODO this should be replaced with the buffered category iterator, as it might produce an
     // HeapSpace Overflow, if there are too many categories.
     protected Set<Integer> __getCategories() {
-        Session session = this.__getHibernateSession();
-        session.beginTransaction();
         String sql = "select cat.pageId from Category as cat";
-        List<Integer> idList = session.createQuery(sql, Integer.class).list();
-        session.getTransaction().commit();
+        List<Integer> idList = __inTransaction(
+                session -> session.createQuery(sql, Integer.class).list());
 
         return new HashSet<>(idList);
     }
@@ -685,11 +649,9 @@ public class Wikipedia
      * @return A set with all {@code pageIDs}. Returning all pages is much to expensive.
      */
     protected Set<Integer> __getPages() {
-        Session session = this.__getHibernateSession();
-        session.beginTransaction();
         String sql = "select page.pageId from Page as page";
-        List<Integer> idList = session.createQuery(sql, Integer.class).list();
-        session.getTransaction().commit();
+        List<Integer> idList = __inTransaction(
+                session -> session.createQuery(sql, Integer.class).list());
 
         return new HashSet<>(idList);
     }
@@ -765,14 +727,10 @@ public class Wikipedia
 
         String encodedTitle = t.getWikiStyleTitle();
 
-        Session session = this.__getHibernateSession();
-        try {
-            session.beginTransaction();
-            var query = "select p.id from PageMapLine as p where p.name = :pName";
-            if (dbConfig.supportsCollation()) {
-                query += SQL_COLLATION;
-            }
+        final String query = "select p.id from PageMapLine as p where p.name = :pName"
+                + (dbConfig.supportsCollation() ? SQL_COLLATION : "");
 
+        return __inTransaction(session -> {
             // Eclipse somehow thinks that setParameter returns a MutationQuery instead of a
             // NativeQuery...
             // A name is not unique in PageMapLine: case variants of one title map to their own
@@ -784,11 +742,8 @@ public class Wikipedia
             var nativeQuery = session.createNativeQuery(query, Long.class)
                     .setParameter("pName", encodedTitle, StandardBasicTypes.STRING)
                     .setMaxResults(1);
-            var returnValue = nativeQuery.uniqueResult();
-            return returnValue != null;
-        } finally {
-            session.getTransaction().commit();
-        }
+            return nativeQuery.uniqueResult();
+        }) != null;
     }
 
     /**
@@ -807,22 +762,15 @@ public class Wikipedia
             return false;
         }
 
-        Session session = this.__getHibernateSession();
-        try {
-            session.beginTransaction();
-            // PageMapLine holds one entry per title the page id can be reached by, so a page that
-            // has redirects carries several of them. One entry answers the question, see
-            // existsPage(String) on why a unique result must not be asked for here.
-            String sql = "select p.id from PageMapLine as p where p.pageID = :pageId";
-            Long returnValue = session.createNativeQuery(sql, Long.class)
-                    .setParameter("pageId", pageID, StandardBasicTypes.INTEGER).setMaxResults(1)
-                    .uniqueResult();
+        // PageMapLine holds one entry per title the page id can be reached by, so a page that has
+        // redirects carries several of them. One entry answers the question, see existsPage(String)
+        // on why a unique result must not be asked for here.
+        String sql = "select p.id from PageMapLine as p where p.pageID = :pageId";
+        Long returnValue = __inTransaction(session -> session.createNativeQuery(sql, Long.class)
+                .setParameter("pageId", pageID, StandardBasicTypes.INTEGER).setMaxResults(1)
+                .uniqueResult());
 
-            return returnValue != null;
-        }
-        finally {
-            session.getTransaction().commit();
-        }
+        return returnValue != null;
     }
 
     /**
@@ -842,12 +790,9 @@ public class Wikipedia
 
         // The id was not found in the id mapping cache.
         // It may not be in the cahe or may not exist at all.
-        Session session = this.__getHibernateSession();
-        session.beginTransaction();
         String sql = "select page.id from Page as page where page.pageId = :pageId";
-        Long retObjectPage = session.createQuery(sql, Long.class)
-                .setParameter("pageId", pageID, StandardBasicTypes.INTEGER).uniqueResult();
-        session.getTransaction().commit();
+        Long retObjectPage = __inTransaction(session -> session.createQuery(sql, Long.class)
+                .setParameter("pageId", pageID, StandardBasicTypes.INTEGER).uniqueResult());
         if (retObjectPage != null) {
             hibernateID = retObjectPage;
             // add it to the cache
@@ -875,12 +820,9 @@ public class Wikipedia
 
         // The id was not found in the id mapping cache.
         // It may not be in the cahe or may not exist at all.
-        Session session = this.__getHibernateSession();
-        session.beginTransaction();
         String sql = "select cat.id from Category as cat where cat.pageId = :pageId";
-        Long retObjectPage = session.createQuery(sql, Long.class)
-                .setParameter("pageId", pageID, StandardBasicTypes.INTEGER).uniqueResult();
-        session.getTransaction().commit();
+        Long retObjectPage = __inTransaction(session -> session.createQuery(sql, Long.class)
+                .setParameter("pageId", pageID, StandardBasicTypes.INTEGER).uniqueResult());
         if (retObjectPage != null) {
             hibernateID = retObjectPage;
             // add it to the cache
@@ -910,6 +852,23 @@ public class Wikipedia
      */
     protected Session __getHibernateSession() {
         return WikiHibernateUtil.getSessionFactory(this.dbConfig).getCurrentSession();
+    }
+
+    /**
+     * Runs a unit of work inside a transaction on the session bound to the current thread.
+     * <p>
+     * This is the shortcut every database access in the API package goes through. Completing the
+     * transaction on the failure paths as well is what keeps a failing query from leaving the
+     * thread-bound session - and the JDBC connection it holds - behind for good; see
+     * {@link WikiHibernateUtil#inTransaction(Session, Function)} for the full story.
+     *
+     * @param work The unit of work to run. Must not be {@code null}, and must not call back into an
+     *             operation that opens a transaction of its own.
+     * @param <T>  The type of the result of {@code work}.
+     * @return Whatever {@code work} returned.
+     */
+    protected <T> T __inTransaction(Function<Session, T> work) {
+        return WikiHibernateUtil.inTransaction(__getHibernateSession(), work);
     }
 
     /**

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/hibernate/WikiHibernateUtil.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/hibernate/WikiHibernateUtil.java
@@ -30,9 +30,11 @@ import java.util.HexFormat;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 import org.dkpro.jwpl.api.DatabaseConfiguration;
 import org.dkpro.jwpl.api.WikiConstants;
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
@@ -344,6 +346,61 @@ public class WikiHibernateUtil
             }
         }
         return null;
+    }
+
+    /**
+     * Runs {@code work} inside a transaction on a specified {@link Session} and commits it.
+     * <p>
+     * JWPL binds its sessions to the current thread
+     * ({@code hibernate.current_session_context_class=thread}), and such a session is unbound and
+     * closed only once its transaction <i>completes</i>. A transaction left open by a failing unit
+     * of work therefore neither releases the session nor its JDBC connection: every later JWPL call
+     * on the same thread fails with {@code IllegalStateException: Transaction already active}, and
+     * a handful of failures exhausts the connection pool for the whole JVM. Which is why the
+     * transaction is completed here on every path, the failure ones included.
+     *
+     * @param session The {@link Session} to run {@code work} on. Must not be {@code null}.
+     * @param work    The unit of work to run. Must not be {@code null}. It must not call back into
+     *                an operation that opens a transaction of its own, as the thread-bound session
+     *                supports no nesting - do that after {@code inTransaction} returned.
+     * @param <T>     The type of the result of {@code work}.
+     * @return Whatever {@code work} returned.
+     */
+    public static <T> T inTransaction(Session session, Function<Session, T> work)
+    {
+        session.beginTransaction();
+        boolean completed = false;
+        try {
+            T result = work.apply(session);
+            session.getTransaction().commit();
+            completed = true;
+            return result;
+        }
+        finally {
+            if (!completed) {
+                rollbackQuietly(session);
+            }
+        }
+    }
+
+    /**
+     * Rolls back the transaction of a specified {@link Session}, if one is still active. A failure
+     * to do so is logged rather than thrown: this runs while another exception is already on its
+     * way out, and that one is the one the caller needs to see.
+     *
+     * @param session The {@link Session} whose transaction to roll back.
+     */
+    private static void rollbackQuietly(Session session)
+    {
+        try {
+            if (session.getTransaction().isActive()) {
+                session.getTransaction().rollback();
+            }
+        }
+        catch (RuntimeException e) {
+            logger.warn("Could not roll back the transaction after a failed unit of work. The "
+                    + "session bound to this thread may stay unusable.", e);
+        }
     }
 
     private static Properties getProperties(DatabaseConfiguration config)

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/util/GraphSerialization.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/util/GraphSerialization.java
@@ -78,13 +78,10 @@ public final class GraphSerialization
         throws IOException
     {
         SerializableDirectedGraph serialGraph = new SerializableDirectedGraph(graph);
-        BufferedOutputStream fos;
-        ObjectOutputStream out;
-        fos = new BufferedOutputStream(new FileOutputStream(file));
-        out = new ObjectOutputStream(fos);
-        out.writeObject(serialGraph);
-        out.close();
-
+        try (ObjectOutputStream out = new ObjectOutputStream(
+                new BufferedOutputStream(new FileOutputStream(file)))) {
+            out.writeObject(serialGraph);
+        }
     }
 
     /**
@@ -129,12 +126,10 @@ public final class GraphSerialization
         throws IOException, ClassNotFoundException
     {
         SerializableDirectedGraph serialGraph;
-        BufferedInputStream fin;
-        ObjectInputStream in;
-        fin = new BufferedInputStream(new FileInputStream(file));
-        in = new ObjectInputStream(fin);
-        serialGraph = (SerializableDirectedGraph) in.readObject();
-        in.close();
+        try (ObjectInputStream in = new ObjectInputStream(
+                new BufferedInputStream(new FileInputStream(file)))) {
+            serialGraph = (SerializableDirectedGraph) in.readObject();
+        }
         return serialGraph.getGraph();
     }
 }

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/util/HibernateUtilities.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/util/HibernateUtilities.java
@@ -18,12 +18,12 @@
 package org.dkpro.jwpl.api.util;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.dkpro.jwpl.api.DatabaseConfiguration;
 import org.dkpro.jwpl.api.WikiConstants;
 import org.dkpro.jwpl.api.hibernate.WikiHibernateUtil;
-import org.hibernate.Session;
 
 /**
  * Provides helpful methods for working with the ORM Hibernate.
@@ -58,15 +58,16 @@ public class HibernateUtilities
     {
         Map<Integer, Long> idMapping = new HashMap<>();
 
-        Session session = WikiHibernateUtil.getSessionFactory(this.dbConfig).getCurrentSession();
-        session.beginTransaction();
-        for (Object o : session.createQuery("select page.id, page.pageId from Page as page")
-                .list()) {
-            Object[] row = (Object[]) o;
+        List<Object[]> rows = WikiHibernateUtil.inTransaction(
+                WikiHibernateUtil.getSessionFactory(this.dbConfig).getCurrentSession(),
+                session -> session
+                        .createQuery("select page.id, page.pageId from Page as page",
+                                Object[].class)
+                        .list());
+        for (Object[] row : rows) {
             // put (pageID, id)
             idMapping.put((Integer) row[1], (Long) row[0]);
         }
-        session.getTransaction().commit();
         return idMapping;
     }
 
@@ -80,15 +81,16 @@ public class HibernateUtilities
     {
         Map<Integer, Long> idMapping = new HashMap<>();
 
-        Session session = WikiHibernateUtil.getSessionFactory(this.dbConfig).getCurrentSession();
-        session.beginTransaction();
-        for (Object o : session.createQuery("select cat.id, cat.pageId from Category as cat")
-                .list()) {
-            Object[] row = (Object[]) o;
+        List<Object[]> rows = WikiHibernateUtil.inTransaction(
+                WikiHibernateUtil.getSessionFactory(this.dbConfig).getCurrentSession(),
+                session -> session
+                        .createQuery("select cat.id, cat.pageId from Category as cat",
+                                Object[].class)
+                        .list());
+        for (Object[] row : rows) {
             // put (pageID, id)
             idMapping.put((Integer) row[1], (Long) row[0]);
         }
-        session.getTransaction().commit();
         return idMapping;
     }
 }

--- a/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/SessionRecoveryTest.java
+++ b/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/SessionRecoveryTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.jwpl.api;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.hibernate.Session;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the recovery of the thread-bound Hibernate session after a failing unit of work.
+ * <p>
+ * JWPL binds a session to the current thread, and such a session is unbound and closed only once
+ * its transaction completes. A transaction left open by a failing query therefore used to leak the
+ * session <i>and</i> the JDBC connection it holds: every later call on that thread failed with
+ * {@code IllegalStateException: Transaction already active}, and a handful of failures exhausted
+ * the connection pool for the whole JVM.
+ *
+ * @see org.dkpro.jwpl.api.hibernate.WikiHibernateUtil#inTransaction
+ */
+public class SessionRecoveryTest
+    extends BaseJWPLTest
+{
+
+    private static final int A_FAMOUS_PAGE_ID = 1017;
+
+    /** Fails at execution time on every supported backend. */
+    private static final String FAILING_QUERY = "select * from NoSuchTableAtAll";
+
+    /**
+     * More failures than either connection pool JWPL configures holds -
+     * {@code hibernate.connection.pool_size} is 5, {@code hibernate.c3p0.max_size} is 15.
+     */
+    private static final int MORE_THAN_THE_POOL_HOLDS = 25;
+
+    @BeforeAll
+    public static void setupWikipedia() throws Exception
+    {
+        wiki = new Wikipedia(obtainDbConfiguration());
+    }
+
+    @Test
+    public void testFailedQueryClosesTheThreadBoundSession()
+    {
+        AtomicReference<Session> used = new AtomicReference<>();
+
+        assertThrows(RuntimeException.class, () -> wiki.__inTransaction(session -> {
+            used.set(session);
+            return session.createNativeQuery(FAILING_QUERY, Object.class).list();
+        }));
+
+        assertFalse(used.get().isOpen(),
+                "A failed unit of work must not leave its session open - it holds a JDBC "
+                        + "connection until the transaction completes.");
+        assertNotSame(used.get(), wiki.__getHibernateSession(),
+                "The failed session must have been unbound from this thread.");
+    }
+
+    @Test
+    public void testThreadStaysUsableAfterAFailedQuery()
+    {
+        assertThrows(RuntimeException.class, () -> wiki
+                .__inTransaction(session -> session.createNativeQuery(FAILING_QUERY, Object.class)
+                        .list()));
+
+        // Used to throw IllegalStateException: Transaction already active.
+        assertTrue(wiki.existsPage(A_FAMOUS_PAGE_ID),
+                "An unrelated call after a failed query must still work on the same thread.");
+    }
+
+    @Test
+    public void testRepeatedFailuresDoNotExhaustTheConnectionPool()
+    {
+        for (int i = 0; i < MORE_THAN_THE_POOL_HOLDS; i++) {
+            assertThrows(RuntimeException.class,
+                    () -> wiki.__inTransaction(session -> session
+                            .createNativeQuery(FAILING_QUERY, Object.class).list()));
+        }
+
+        // Used to fail with "The internal connection pool has reached its maximum size and no
+        // connection is currently available" once the pool ran dry.
+        assertTrue(wiki.existsPage(A_FAMOUS_PAGE_ID),
+                "Failed queries must return their connections to the pool.");
+    }
+}

--- a/dkpro-jwpl-datamachine/src/main/java/org/dkpro/jwpl/datamachine/dump/xml/XML2Binary.java
+++ b/dkpro-jwpl-datamachine/src/main/java/org/dkpro/jwpl/datamachine/dump/xml/XML2Binary.java
@@ -48,7 +48,8 @@ public class XML2Binary
     /**
      * Instantiates a {@link XML2Binary} object with the specified parameters.
      *
-     * @param iStream   The {@link InputStream} containing the XML data to process.
+     * @param iStream   The {@link InputStream} containing the XML data to process. It is closed
+     *                  before this constructor returns, on the failure paths as well.
      * @param files     The {@link DataMachineFiles} configuration to apply.
      * @throws IOException Thrown if IO errors occurred during processing.
      */
@@ -56,13 +57,16 @@ public class XML2Binary
     {
         final DumpWriter writer = new NamespaceFilter(new SimpleBinaryDumpWriter(files),
                 ENABLED_NAMESPACES);
-        if (USE_MODIFIED_PARSER) {
-            // modified parser, skips faulty tags
-            new SimpleXmlDumpReader(iStream, writer).readDump();
-        }
-        else {
-            // original MWDumper parser, very sensible to not closed tags
-            new XmlDumpReader(iStream, writer).readDump();
+        // Ownership of the stream is taken over here, exactly as the multi-part constructor does.
+        try (iStream) {
+            if (USE_MODIFIED_PARSER) {
+                // modified parser, skips faulty tags
+                new SimpleXmlDumpReader(iStream, writer).readDump();
+            }
+            else {
+                // original MWDumper parser, very sensible to not closed tags
+                new XmlDumpReader(iStream, writer).readDump();
+            }
         }
     }
 

--- a/dkpro-jwpl-parser/src/main/java/org/dkpro/jwpl/parser/selectiveaccess/SelectiveAccessHandler.java
+++ b/dkpro-jwpl-parser/src/main/java/org/dkpro/jwpl/parser/selectiveaccess/SelectiveAccessHandler.java
@@ -447,9 +447,7 @@ public class SelectiveAccessHandler
      */
     public void writeConfig(String XMLFile)
     {
-        try {
-            BufferedWriter bw = new BufferedWriter(new FileWriter(XMLFile));
-
+        try (BufferedWriter bw = new BufferedWriter(new FileWriter(XMLFile))) {
             bw.write("<SelectiveAccessHandlerConfig>\n");
             bw.write("<page>" + XMLCIT(pageHandling) + "</page>\n");
             bw.write("<firstparagraph>" + XMLCIT(pageHandling) + "</firstparagraph>\n");
@@ -459,8 +457,6 @@ public class SelectiveAccessHandler
                 bw.write("</section>\n");
             }
             bw.write("<SelectiveAccessHandlerConfig>\n");
-
-            bw.close();
         }
         catch (IOException e) {
             logger.error("Could not write configuration to '{}'.", XMLFile, e);

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/api/AbstractRevisionService.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/api/AbstractRevisionService.java
@@ -27,8 +27,12 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A common base class that handles the aspect of database connection handling.
+ * <p>
+ * Implementations own the database connection they open, hence they must be closed by their
+ * caller - use them as a resource of a try-with-resources statement.
  */
 public abstract class AbstractRevisionService
+    implements AutoCloseable
 {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractRevisionService.class);
@@ -80,6 +84,7 @@ public abstract class AbstractRevisionService
      * @throws SQLException
      *             if an error occurs while closing the connection
      */
+    @Override
     public final void close() throws SQLException
     {
         if (this.connection != null) {

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/api/ChronoRevisionIterator.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/api/ChronoRevisionIterator.java
@@ -50,6 +50,13 @@ public class ChronoRevisionIterator
     private ResultSet resultArticles;
 
     /**
+     * Reference to the statement that produced {@link #resultArticles}. It is kept so that it can
+     * be closed along with the result set - a statement left behind holds server side resources
+     * for the whole lifetime of the connection.
+     */
+    private Statement articlesStatement;
+
+    /**
      * Number of revisions of the current read article
      */
     private int maxRevision;
@@ -161,14 +168,15 @@ public class ChronoRevisionIterator
      */
     private boolean queryArticle() throws SQLException
     {
+        closeArticleResources();
 
-        Statement statement = this.connection.createStatement();
+        articlesStatement = this.connection.createStatement();
 
         String query = "SELECT ArticleID, FullRevisionPKs, RevisionCounter "
                 + "FROM index_articleID_rc_ts " + "WHERE articleID > " + this.currentArticleID
                 + " LIMIT " + MAX_NUMBER_RESULTS;
 
-        resultArticles = statement.executeQuery(query);
+        resultArticles = articlesStatement.executeQuery(query);
 
         if (resultArticles.next()) {
 
@@ -321,7 +329,6 @@ public class ChronoRevisionIterator
                             || (this.currentArticleID <= this.lastArticleID);
                 }
 
-                resultArticles.close();
                 return queryArticle();
 
             case ITERATE_WITHOUT_MAPPING:
@@ -339,7 +346,6 @@ public class ChronoRevisionIterator
                             || (this.currentArticleID <= this.lastArticleID);
                 }
 
-                resultArticles.close();
                 return queryArticle();
 
             default:
@@ -373,8 +379,33 @@ public class ChronoRevisionIterator
     @Override
     public void close() throws SQLException
     {
-        if (this.connection != null) {
-            this.connection.close();
+        try {
+            closeArticleResources();
+        }
+        finally {
+            if (this.connection != null) {
+                this.connection.close();
+            }
+        }
+    }
+
+    /**
+     * Closes the statement of the current article batch, and with it the result set it produced.
+     *
+     * @throws SQLException
+     *             if an error occurs while closing the statement
+     */
+    private void closeArticleResources() throws SQLException
+    {
+        try {
+            if (articlesStatement != null) {
+                // Closing a statement closes the result set it produced along with it.
+                articlesStatement.close();
+            }
+        }
+        finally {
+            articlesStatement = null;
+            resultArticles = null;
         }
     }
 

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/api/RevisionApi.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/api/RevisionApi.java
@@ -117,18 +117,21 @@ public class RevisionApi
                 throw new IllegalArgumentException("minNumberRevisions needs to be >= 0");
             }
 
-            PreparedStatement statement;
-
+            boolean columnExists;
             // check whether the field has already been added
-            statement = this.connection.prepareStatement(
+            try (PreparedStatement statement = this.connection.prepareStatement(
                     "SELECT * FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '"
                             + config.getDatabase()
-                            + "' AND TABLE_NAME = 'index_articleID_rc_ts' AND COLUMN_NAME = 'NumberRevisions'");
-            if (!statement.executeQuery().next()) {
+                            + "' AND TABLE_NAME = 'index_articleID_rc_ts' AND COLUMN_NAME = 'NumberRevisions'")) {
+                try (ResultSet result = statement.executeQuery()) {
+                    columnExists = result.next();
+                }
+            }
+
+            if (!columnExists) {
                 // create new column
-                statement = this.connection.prepareStatement(
-                        "ALTER TABLE index_articleID_rc_ts ADD NumberRevisions INT(10) unsigned NOT NULL");
-                try {
+                try (PreparedStatement statement = this.connection.prepareStatement(
+                        "ALTER TABLE index_articleID_rc_ts ADD NumberRevisions INT(10) unsigned NOT NULL")) {
                     statement.execute();
                 }
                 catch (SQLException e) {
@@ -137,37 +140,30 @@ public class RevisionApi
                             e);
                 }
                 // fill with information extracted from RevisionCounter field
-                statement = this.connection.prepareStatement(
-                        "UPDATE index_articleID_rc_ts SET NumberRevisions = (SELECT SUBSTRING_INDEX(RevisionCounter,' ',-1))");
-                statement.execute();
+                String fill = "UPDATE index_articleID_rc_ts SET NumberRevisions = "
+                        + "(SELECT SUBSTRING_INDEX(RevisionCounter,' ',-1))";
+                try (PreparedStatement statement = this.connection.prepareStatement(fill)) {
+                    statement.execute();
+                }
             }
 
             HashSet<Integer> articles = new HashSet<>();
 
             // make query
-            try {
-                if (maxNumberRevisions == -1) {
-                    statement = this.connection
-                            .prepareStatement("SELECT ArticleID FROM index_articleID_rc_ts "
-                                    + "WHERE NumberRevisions >= ?");
-                    statement.setInt(1, minNumberRevisions);
-                }
-                else {
-                    statement = this.connection
-                            .prepareStatement("SELECT ArticleID FROM index_articleID_rc_ts "
-                                    + "WHERE NumberRevisions BETWEEN ? AND ?");
-                    statement.setInt(1, minNumberRevisions);
+            String sql = maxNumberRevisions == -1
+                    ? "SELECT ArticleID FROM index_articleID_rc_ts WHERE NumberRevisions >= ?"
+                    : "SELECT ArticleID FROM index_articleID_rc_ts "
+                            + "WHERE NumberRevisions BETWEEN ? AND ?";
+            try (PreparedStatement statement = this.connection.prepareStatement(sql)) {
+                statement.setInt(1, minNumberRevisions);
+                if (maxNumberRevisions != -1) {
                     statement.setInt(2, maxNumberRevisions);
                 }
-                ResultSet result = statement.executeQuery();
 
-                while (result.next()) {
-                    articles.add(result.getInt(1));
-                }
-            }
-            finally {
-                if (statement != null) {
-                    statement.close();
+                try (ResultSet result = statement.executeQuery()) {
+                    while (result.next()) {
+                        articles.add(result.getInt(1));
+                    }
                 }
             }
             return articles;

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/archivers/Bzip2Archiver.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/archivers/Bzip2Archiver.java
@@ -53,43 +53,31 @@ public class Bzip2Archiver
      */
     public void compress(String path)
     {
-        try {
+        File fileToArchive = new File(path);
+        File archivedFile = new File(fileToArchive.getName() + ".bz2");
 
-            File fileToArchive = new File(path);
+        try (BufferedInputStream input = new BufferedInputStream(
+                new FileInputStream(fileToArchive))) {
 
-            BufferedInputStream input = new BufferedInputStream(new FileInputStream(fileToArchive));
-
-            File archivedFile = new File(fileToArchive.getName() + ".bz2");
             archivedFile.createNewFile();
 
-            FileOutputStream fos = new FileOutputStream(archivedFile);
-            BufferedOutputStream bufStr = new BufferedOutputStream(fos);
-            // added bzip2 prefix
-            fos.write("BZ".getBytes());
-            BZip2CompressorOutputStream bzip2 = new BZip2CompressorOutputStream(bufStr);
+            try (FileOutputStream fos = new FileOutputStream(archivedFile)) {
+                BufferedOutputStream bufStr = new BufferedOutputStream(fos);
+                // added bzip2 prefix
+                fos.write("BZ".getBytes());
 
-            while (input.available() > 0) {
-                int size = COMPRESSION_CACHE;
-
-                if (input.available() < COMPRESSION_CACHE) {
-                    size = input.available();
+                try (BZip2CompressorOutputStream bzip2 = new BZip2CompressorOutputStream(bufStr)) {
+                    byte[] bytes = new byte[COMPRESSION_CACHE];
+                    int read;
+                    while ((read = input.read(bytes)) != -1) {
+                        bzip2.write(bytes, 0, read);
+                    }
                 }
-                byte[] bytes = new byte[size];
-
-                input.read(bytes);
-
-                bzip2.write(bytes);
             }
-            bzip2.close();
-            bufStr.close();
-            fos.close();
-            input.close();
-
         }
         catch (IOException e) {
             logger.error("Could not compress file [{}]", path, e);
         }
-
     }
 
     /**
@@ -147,33 +135,26 @@ public class Bzip2Archiver
 
         unarchived.createNewFile();
 
-        BufferedInputStream inputStr = new BufferedInputStream(new FileInputStream(bzip2));
+        try (BufferedInputStream inputStr = new BufferedInputStream(new FileInputStream(bzip2))) {
 
-        // read bzip2 prefix
-        inputStr.read();
-        inputStr.read();
+            // read bzip2 prefix
+            inputStr.read();
+            inputStr.read();
 
-        BufferedInputStream buffStr = new BufferedInputStream(inputStr);
+            try (BZip2CompressorInputStream input = new BZip2CompressorInputStream(
+                    new BufferedInputStream(inputStr));
+                    FileOutputStream outStr = new FileOutputStream(unarchived)) {
 
-        BZip2CompressorInputStream input = new BZip2CompressorInputStream(buffStr);
-
-        FileOutputStream outStr = new FileOutputStream(unarchived);
-
-        while (true) {
-            byte[] compressedBytes = new byte[DECOMPRESSION_CACHE];
-
-            int byteRead = input.read(compressedBytes);
-
-            outStr.write(compressedBytes, 0, byteRead);
-            if (byteRead != DECOMPRESSION_CACHE) {
-                break;
+                byte[] compressedBytes = new byte[DECOMPRESSION_CACHE];
+                int byteRead;
+                // A short read is not the end of the stream - only a -1 is, which the previous
+                // 'read fewer bytes than asked for' check mistook for it (and then wrote a -1
+                // length chunk).
+                while ((byteRead = input.read(compressedBytes)) != -1) {
+                    outStr.write(compressedBytes, 0, byteRead);
+                }
             }
         }
-
-        input.close();
-        buffStr.close();
-        inputStr.close();
-        outStr.close();
     }
 
 }

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/dump/writer/SQLDatabaseWriter.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/dump/writer/SQLDatabaseWriter.java
@@ -90,13 +90,42 @@ public class SQLDatabaseWriter
 
             this.connection = DriverManager.getConnection("jdbc:mysql://" + host + "/" + sTable,
                     user, password);
-
-            init();
-            writeHeader();
-
         }
         catch (ClassNotFoundException | SQLException e) {
             throw new ConfigurationException(e);
+        }
+
+        // The connection is open by now, and no caller can reach it any more once the
+        // constructor fails - so every failure below has to release it.
+        try {
+            init();
+            writeHeader();
+        }
+        catch (SQLException e) {
+            ConfigurationException wrapped = new ConfigurationException(e);
+            closeQuietly(wrapped);
+            throw wrapped;
+        }
+        catch (ConfigurationException | LoggingException | RuntimeException e) {
+            closeQuietly(e);
+            throw e;
+        }
+    }
+
+    /**
+     * Closes the database connection while another failure is already on its way out. A failure to
+     * do so is attached to that one rather than replacing it.
+     *
+     * @param primary
+     *            The failure that made the connection unreachable.
+     */
+    private void closeQuietly(Exception primary)
+    {
+        try {
+            close();
+        }
+        catch (SQLException e) {
+            primary.addSuppressed(e);
         }
     }
 
@@ -149,13 +178,11 @@ public class SQLDatabaseWriter
         try {
             queries = sqlEncoder.encodeTask(task);
 
-            Statement query;
             int size = queries.length;
             for (i = 0; i < size; i++) {
-
-                query = connection.createStatement();
-                query.executeUpdate(queries[i].getQuery());
-                query.close();
+                try (Statement query = connection.createStatement()) {
+                    query.executeUpdate(queries[i].getQuery());
+                }
             }
             // System.out.println(task.toString());
 
@@ -191,17 +218,13 @@ public class SQLDatabaseWriter
     private void writeHeader() throws SQLException
     {
 
-        Statement query;
-        String[] revTableHeaderQueries;
-
-        revTableHeaderQueries = sqlEncoder.getTable();
+        String[] revTableHeaderQueries = sqlEncoder.getTable();
 
         // commit revision table header
         for (String revTableHeaderQuery : revTableHeaderQueries) {
-            query = connection.createStatement();
-
-            query.executeUpdate(revTableHeaderQuery);
-            query.close();
+            try (Statement query = connection.createStatement()) {
+                query.executeUpdate(revTableHeaderQuery);
+            }
         }
 
     }

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/index/IndexGenerator.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/index/IndexGenerator.java
@@ -21,7 +21,6 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.Objects;
 import java.util.Properties;
 
@@ -76,18 +75,19 @@ public class IndexGenerator
             long count = 0;
             long last = 0, now, start = System.currentTimeMillis();
 
-            Iterator<Revision> it = new IndexIterator(config);
-            while (it.hasNext()) {
+            try (IndexIterator it = new IndexIterator(config)) {
+                while (it.hasNext()) {
 
-                if (++count % bufferSize == 0) {
-                    now = System.currentTimeMillis() - start;
-                    System.out.println(
-                            Time.toClock(now) + "\t" + (now - last) + "\tINDEXING " + count);
-                    last = now;
+                    if (++count % bufferSize == 0) {
+                        now = System.currentTimeMillis() - start;
+                        System.out.println(
+                                Time.toClock(now) + "\t" + (now - last) + "\tINDEXING " + count);
+                        last = now;
+                    }
+
+                    rev = it.next();
+                    data.index(rev);
                 }
-
-                rev = it.next();
-                data.index(rev);
             }
 
             System.out.println("GENERATING INDEX ENDED + ("

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/index/IndexIterator.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/index/IndexIterator.java
@@ -31,9 +31,12 @@ import org.dkpro.jwpl.revisionmachine.api.RevisionAPIConfiguration;
 
 /**
  * Iterates over the database to retrieve the necessary information for the index generation.
+ * <p>
+ * The iterator owns the database connection it opens, hence it must be closed by its caller - use
+ * it as a resource of a try-with-resources statement.
  */
 public class IndexIterator
-    implements Iterator<Revision>
+    implements Iterator<Revision>, AutoCloseable
 {
 
     /**
@@ -159,18 +162,57 @@ public class IndexIterator
                 return true;
             }
 
-            if (this.statement != null) {
-                this.statement.close();
-            }
-            if (this.result != null) {
-                this.result.close();
+            closeResultResources();
+
+            if (query()) {
+                return true;
             }
 
-            return query();
-
+            // The batch came back empty - release what the query opened right away instead of
+            // holding a statement and a result set until the iterator itself is closed.
+            closeResultResources();
+            return false;
         }
         catch (SQLException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Closes the {@link Statement} of the current batch, and with it the {@link ResultSet} it
+     * produced, so that a new batch can be queried.
+     *
+     * @throws SQLException
+     *             if an error occurs while closing the statement
+     */
+    private void closeResultResources() throws SQLException
+    {
+        try {
+            if (statement != null) {
+                // Closing a statement closes the result set it produced along with it.
+                statement.close();
+            }
+        }
+        finally {
+            statement = null;
+            result = null;
+        }
+    }
+
+    /**
+     * Closes the current batch and the database connection this iterator opened.
+     *
+     * @throws SQLException
+     *             if an error occurs while closing the connection
+     */
+    @Override
+    public void close() throws SQLException
+    {
+        try {
+            closeResultResources();
+        }
+        finally {
+            connection.close();
         }
     }
 

--- a/dkpro-jwpl-wikimachine/src/main/java/org/dkpro/jwpl/wikimachine/decompression/UniversalDecompressor.java
+++ b/dkpro-jwpl-wikimachine/src/main/java/org/dkpro/jwpl/wikimachine/decompression/UniversalDecompressor.java
@@ -20,6 +20,7 @@ package org.dkpro.jwpl.wikimachine.decompression;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -207,19 +208,37 @@ public class UniversalDecompressor
      */
     private InputStream startExternal(String fileName)
     {
-        InputStream result = null;
         try {
             String extension = detectExtension(fileName);
             String command = externalSupport.get(extension).replace(FILEPLACEHOLDER, fileName);
-            Process externalProcess = Runtime.getRuntime().exec(command);
-            result = externalProcess.getInputStream();
+            // The error stream is inherited rather than left to fill up: nothing here drains it,
+            // and once its buffer runs full the external decompressor blocks for good, taking the
+            // whole import with it. It must not be merged into the standard output either - that
+            // is the dump being read.
+            Process externalProcess = new ProcessBuilder(command.split("\\s+"))
+                    .redirectError(ProcessBuilder.Redirect.INHERIT).start();
+            // Closing the returned stream is what the caller does when it is done reading, and
+            // that is when the process has to go as well - it cannot be reached any other way.
+            return new FilterInputStream(externalProcess.getInputStream())
+            {
+                @Override
+                public void close() throws IOException
+                {
+                    try {
+                        super.close();
+                    }
+                    finally {
+                        externalProcess.destroy();
+                    }
+                }
+            };
         }
         catch (IOException e) {
           // Handled here: the caller is signalled by the 'null' return value, so this is the
           // only place the underlying cause is recorded.
           LOG.error("Could not start the external decompressor for '{}'.", fileName, e);
         }
-        return result;
+        return null;
     }
 
     /**

--- a/dkpro-jwpl-wikimachine/src/main/java/org/dkpro/jwpl/wikimachine/domain/DumpVersionProcessor.java
+++ b/dkpro-jwpl-wikimachine/src/main/java/org/dkpro/jwpl/wikimachine/domain/DumpVersionProcessor.java
@@ -97,24 +97,24 @@ public class DumpVersionProcessor
      */
     public void processRevision(RevisionParser revisionParser) throws IOException
     {
-        for (IDumpVersion version : versions) {
-            version.initRevisionParsing();
-        }
-        int counter = 0;
-        while (revisionParser.next()) {
+        try (revisionParser) {
             for (IDumpVersion version : versions) {
-                version.processRevisionRow(revisionParser);
+                version.initRevisionParsing();
+            }
+            int counter = 0;
+            while (revisionParser.next()) {
+                for (IDumpVersion version : versions) {
+                    version.processRevisionRow(revisionParser);
+                }
+
+                logAndClear(++counter, "Revision");
             }
 
-            logAndClear(++counter, "Revision");
+            for (IDumpVersion version : versions) {
+                version.exportAfterRevisionParsing();
+                version.freeAfterRevisionParsing();
+            }
         }
-
-        for (IDumpVersion version : versions) {
-            version.exportAfterRevisionParsing();
-            version.freeAfterRevisionParsing();
-        }
-
-        revisionParser.close();
     }
 
     /**
@@ -126,24 +126,24 @@ public class DumpVersionProcessor
      */
     public void processPage(PageParser pageParser) throws IOException
     {
-        for (IDumpVersion version : versions) {
-            version.initPageParsing();
-        }
-
-        int counter = 0;
-        while (pageParser.next()) {
+        try (pageParser) {
             for (IDumpVersion version : versions) {
-                version.processPageRow(pageParser);
+                version.initPageParsing();
             }
-            logAndClear(++counter, "Pages");
-        }
 
-        for (IDumpVersion version : versions) {
-            version.exportAfterPageParsing();
-            version.freeAfterPageParsing();
-        }
+            int counter = 0;
+            while (pageParser.next()) {
+                for (IDumpVersion version : versions) {
+                    version.processPageRow(pageParser);
+                }
+                logAndClear(++counter, "Pages");
+            }
 
-        pageParser.close();
+            for (IDumpVersion version : versions) {
+                version.exportAfterPageParsing();
+                version.freeAfterPageParsing();
+            }
+        }
     }
 
     /**
@@ -214,30 +214,30 @@ public class DumpVersionProcessor
      */
     public void processText(TextParser textParser) throws IOException
     {
-        for (IDumpVersion version : versions) {
-            version.initTextParsing();
-        }
-
-        int counter = 0;
-        while (textParser.next()) {
+        try (textParser) {
             for (IDumpVersion version : versions) {
-                version.processTextRow(textParser);
+                version.initTextParsing();
             }
-            if (step2Flush != 0 && counter % step2Flush == 0) {
+
+            int counter = 0;
+            while (textParser.next()) {
                 for (IDumpVersion version : versions) {
-                    version.flushByTextParsing();
+                    version.processTextRow(textParser);
                 }
+                if (step2Flush != 0 && counter % step2Flush == 0) {
+                    for (IDumpVersion version : versions) {
+                        version.flushByTextParsing();
+                    }
+                }
+                logAndClear(++counter, "Text");
+
             }
-            logAndClear(++counter, "Text");
 
+            for (IDumpVersion version : versions) {
+                version.exportAfterTextParsing();
+                version.freeAfterTextParsing();
+            }
         }
-
-        for (IDumpVersion version : versions) {
-            version.exportAfterTextParsing();
-            version.freeAfterTextParsing();
-        }
-
-        textParser.close();
     }
 
     /**


### PR DESCRIPTION
Fixes leaked Hibernate sessions, JDBC connections/statements and streams.

The main one is in `-api`: sessions are bound to the thread and are only closed once their transaction completes, so a failing query left the session and its JDBC connection behind for good. Every later call on that thread then failed with `Transaction already active`, and a handful of failures exhausted the connection pool for the whole JVM. All 56 call sites now run through a helper that completes the transaction on the failure paths as well; `SessionRecoveryTest` covers it.

The second commit is the mechanical part: statements, connections and streams that were released by a trailing statement instead of try-with-resources, in `-revisionmachine`, `-wikimachine`, `-datamachine`, `-parser` and `-api`. `IndexIterator` had no `close()` at all.

`mvn clean verify -Ptest-e2e-tools -Prat-check` is green.