### PR TITLE
#94: Cap hyponym counts while they are computed instead of afterwards

### DIFF
--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/CategoryGraph.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/CategoryGraph.java
@@ -745,15 +745,52 @@ public class CategoryGraph
         String hyponymCountMapFilename = "hypoCountMap";
         File hyponymCountMapSerializedFile = new File(
                 wiki.getWikipediaId() + "_" + hyponymCountMapFilename);
-        hyponymCountMap = new HashMap<>();
 
         if (hyponymCountMapSerializedFile.exists()) {
             logger.info("Loading saved hyponymyCountMap ...");
-            hyponymCountMap = (Map<Integer, Integer>) this
+            Map<Integer, Integer> savedMap = (Map<Integer, Integer>) this
                     .deserializeMap(hyponymCountMapSerializedFile);
-            logger.info("Done loading saved hyponymyCountMap");
-            return;
+            // Maps written before the counting was capped may hold negative counts, which are the
+            // result of an overflow of the summation (see issue #94). Such a map is unusable, so
+            // it is discarded and computed anew rather than propagated into the measures.
+            if (containsNegativeCount(savedMap)) {
+                logger.warn(
+                        "Discarding the saved hyponymyCountMap in {}: it holds negative hyponym "
+                                + "counts, which an earlier version of JWPL could produce. It is "
+                                + "computed again and overwritten.",
+                        hyponymCountMapSerializedFile);
+            }
+            else {
+                hyponymCountMap = savedMap;
+                logger.info("Done loading saved hyponymyCountMap");
+                return;
+            }
         }
+
+        hyponymCountMap = __computeHyponymCountMap();
+
+        if (hyponymCountMap.size() != graph.vertexSet().size()) {
+            throw new WikiApiException(
+                    "HyponymCountMap does not contain an entry for each node in the graph."
+                            + hyponymCountMap.size() + "/" + graph.vertexSet().size());
+        }
+
+        logger.info("Computed hyponymCountMap");
+        serializeMap(hyponymCountMap, hyponymCountMapSerializedFile);
+        logger.info("Serialized hyponymCountMap");
+    }
+
+    /**
+     * Computes the (recursive) number of hyponyms of each node of the graph, working upwards from
+     * the leaf nodes so that the count of a node is available once all of its children have one.
+     *
+     * @return A map from each node of the graph to its hyponym count.
+     * @throws WikiApiException
+     *             Thrown if not every node of the graph could be visited.
+     */
+    Map<Integer, Integer> __computeHyponymCountMap() throws WikiApiException
+    {
+        Map<Integer, Integer> result = new HashMap<>();
 
         // a queue holding the nodes to process
 
@@ -783,12 +820,15 @@ public class CategoryGraph
             Set<Integer> children = __getChildren(currNode);
 
             int validChildren = 0;
-            int sumChildHyponyms = 0;
+            // The counts are summed in a long: a node that is reachable over several paths is
+            // counted once per path, so the sum can grow far beyond the number of nodes in the
+            // graph - in a Wikipedia sized graph well beyond Integer.MAX_VALUE (see issue #94).
+            long sumChildHyponyms = 0;
             boolean invalid = false;
             for (int child : children) {
                 if (graph.containsVertex(child)) {
-                    if (hyponymCountMap.containsKey(child)) {
-                        sumChildHyponyms += hyponymCountMap.get(child);
+                    if (result.containsKey(child)) {
+                        sumChildHyponyms += result.get(child);
                         validChildren++;
                     }
                     else {
@@ -809,8 +849,8 @@ public class CategoryGraph
 
             // number of hyponyms of current node is the number of its own hyponomies and the sum
             // of the hyponomies of its children.
-            int currNodeHyponymCount = validChildren + sumChildHyponyms;
-            hyponymCountMap.put(currNode, currNodeHyponymCount);
+            long currNodeHyponymCount = validChildren + sumChildHyponyms;
+            result.put(currNode, capHyponymCount(currNodeHyponymCount));
 
             // add parents of current node to queue
             for (int parent : __getParents(currNode)) {
@@ -826,35 +866,35 @@ public class CategoryGraph
             throw new WikiApiException("Visited only " + visited.size() + " out of "
                     + graph.vertexSet().size() + " nodes.");
         }
-        if (hyponymCountMap.size() != graph.vertexSet().size()) {
-            throw new WikiApiException(
-                    "HyponymCountMap does not contain an entry for each node in the graph."
-                            + hyponymCountMap.size() + "/" + graph.vertexSet().size());
-        }
 
-        scaleHyponymCountMap();
-        logger.info("Computed hyponymCountMap");
-        serializeMap(hyponymCountMap, hyponymCountMapSerializedFile);
-        logger.info("Serialized hyponymCountMap");
+        return result;
     }
 
     /**
-     * As the categoryGraph is a graph rather than a tree, the hyponymCount for top nodes can be
+     * As the categoryGraph is a graph rather than a tree, the hyponym count of a node can come out
      * greater than the number of nodes in the graph. This is due to the multiple counting of nodes
-     * having more than one parent. Thus, we have to scale hyponym counts to fall in
-     * [0,NumberOfNodes].
+     * having more than one parent. Counts are therefore capped to fall in [0,NumberOfNodes], which
+     * also keeps the summation of the counts of the parents of such a node away from an overflow.
      *
-     * @throws WikiApiException
-     *             Thrown if errors occurred.
+     * @param count
+     *            The counted number of hyponyms of a node.
+     * @return The count, capped at the number of nodes in the graph.
      */
-    private void scaleHyponymCountMap() throws WikiApiException
+    private int capHyponymCount(long count)
     {
-        for (int key : getHyponymCountMap().keySet()) {
-            if (getHyponymCountMap().get(key) > graph.vertexSet().size()) {
-                // TODO scaling function is not optimal (to say the least :)
-                getHyponymCountMap().put(key, (graph.vertexSet().size() - 1));
-            }
-        }
+        int numberOfNodes = graph.vertexSet().size();
+        // TODO capping is not optimal (to say the least :)
+        return count > numberOfNodes ? numberOfNodes - 1 : (int) count;
+    }
+
+    /**
+     * @param countMap
+     *            A map from nodes to hyponym counts.
+     * @return {@code true} if any node is mapped to a negative count.
+     */
+    private static boolean containsNegativeCount(Map<Integer, Integer> countMap)
+    {
+        return countMap.values().stream().anyMatch(count -> count < 0);
     }
 
     /**

--- a/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/CategoryGraphHyponymCountTest.java
+++ b/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/CategoryGraphHyponymCountTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.jwpl.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.dkpro.jwpl.api.exception.WikiApiException;
+import org.jgrapht.graph.DefaultDirectedGraph;
+import org.jgrapht.graph.DefaultEdge;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the hyponym counting of {@link CategoryGraph} on graphs that are built in memory, so that
+ * shapes a Wikipedia sized category graph has but the test fixture does not - most of all a node
+ * reachable over a great many paths - can be asserted without a database.
+ */
+class CategoryGraphHyponymCountTest
+{
+
+    /**
+     * Builds a graph over the given edges, where an edge points from a category to one of its
+     * children.
+     */
+    private static CategoryGraph graphOf(int[][] edges)
+    {
+        DefaultDirectedGraph<Integer, DefaultEdge> graph = new DefaultDirectedGraph<>(
+                DefaultEdge.class);
+        for (int[] edge : edges) {
+            graph.addVertex(edge[0]);
+            graph.addVertex(edge[1]);
+            graph.addEdge(edge[0], edge[1]);
+        }
+        return new CategoryGraph(null, graph);
+    }
+
+    @Test
+    void countsTheHyponymsOfEachNodeOnceForEveryPathLeadingToIt() throws WikiApiException
+    {
+        // 1 is the parent of 2 and 3, which are both parents of the leaf 4
+        CategoryGraph catGraph = graphOf(new int[][] { { 1, 2 }, { 1, 3 }, { 2, 4 }, { 3, 4 } });
+
+        Map<Integer, Integer> hyponymCountMap = catGraph.__computeHyponymCountMap();
+
+        assertEquals(0, hyponymCountMap.get(4));
+        assertEquals(1, hyponymCountMap.get(2));
+        assertEquals(1, hyponymCountMap.get(3));
+        // node 4 is reachable over two paths and is counted once per path, which is what makes the
+        // counts of the upper nodes of a real category graph grow so quickly
+        assertEquals(4, hyponymCountMap.get(1));
+    }
+
+    /**
+     * A chain of diamonds, in which the count of a node is {@code 4 + 2 * count(next node)}: it
+     * doubles per level, so that a graph of less than a hundred nodes reaches counts that no longer
+     * fit into an {@code int}. That is the shape which used to turn the counts negative and every
+     * measure built on them into -1 (see issue #94).
+     */
+    @Test
+    void capsTheCountsOfAGraphWhoseCountsExceedTheRangeOfAnInt() throws WikiApiException
+    {
+        final int levels = 40;
+        int[][] edges = new int[4 * levels][];
+        for (int level = 0; level < levels; level++) {
+            int node = 10 * level;
+            int left = node + 1;
+            int right = node + 2;
+            int next = 10 * (level + 1);
+            edges[4 * level] = new int[] { node, left };
+            edges[4 * level + 1] = new int[] { node, right };
+            edges[4 * level + 2] = new int[] { left, next };
+            edges[4 * level + 3] = new int[] { right, next };
+        }
+        CategoryGraph catGraph = graphOf(edges);
+        int numberOfNodes = catGraph.getNumberOfNodes();
+
+        Map<Integer, Integer> hyponymCountMap = catGraph.__computeHyponymCountMap();
+
+        assertEquals(numberOfNodes, hyponymCountMap.size());
+        for (Map.Entry<Integer, Integer> entry : hyponymCountMap.entrySet()) {
+            assertTrue(entry.getValue() >= 0,
+                    "Node " + entry.getKey() + " has a negative hyponym count of "
+                            + entry.getValue());
+            assertTrue(entry.getValue() <= numberOfNodes,
+                    "Node " + entry.getKey() + " has more hyponyms (" + entry.getValue()
+                            + ") than the graph has nodes (" + numberOfNodes + ")");
+        }
+        // the root of the chain reaches every other node, so its count is capped
+        assertEquals(numberOfNodes - 1, hyponymCountMap.get(0));
+        // the leaf of the chain has none
+        assertEquals(0, hyponymCountMap.get(10 * levels));
+    }
+}


### PR DESCRIPTION
Sums the hyponym counts in a long and caps them as each node is computed, so they can no longer overflow into the negative counts that made getIntrinsicInformationContent() return -1. Fixes #94