### PR TITLE
#151: Parse the entries of a gallery as images

### DIFF
--- a/dkpro-jwpl-parser/src/main/java/org/dkpro/jwpl/parser/mediawiki/ModularParser.java
+++ b/dkpro-jwpl-parser/src/main/java/org/dkpro/jwpl/parser/mediawiki/ModularParser.java
@@ -962,7 +962,7 @@ public class ModularParser
                     // images
                     for (String s : tokenize(sm, startSpan.getEnd(), endSpan.getStart(),
                             lineSeparator)) {
-                        sb.append("[[" + s + "]]" + lineSeparator);
+                        sb.append("[[" + qualifyGalleryEntry(s) + "]]" + lineSeparator);
                     }
 
                     // replace the source and remove the tags
@@ -970,6 +970,32 @@ public class ModularParser
                 }
             }
         }
+    }
+
+    /**
+     * Every line of a gallery names a file, whether or not it carries the namespace prefix that a
+     * link outside a gallery needs. The prefix is therefore added where it is missing, so that the
+     * link the gallery is turned into is recognized as an image rather than as an internal link to
+     * an article of that name (see issue #151).
+     *
+     * @param entry One line of a gallery, that is, a file name followed by the optional caption.
+     * @return The entry, prefixed with an image identifier unless it already carries one.
+     */
+    private String qualifyGalleryEntry(String entry)
+    {
+        if (imageIdentifiers.isEmpty()) {
+            return entry;
+        }
+
+        String namespace = getLinkNameSpace(entry);
+        if (namespace != null && imageIdentifiers.contains(namespace)) {
+            return entry;
+        }
+
+        // the identifiers are kept in lower case for the comparison above, while a namespace
+        // prefix is conventionally capitalized
+        String identifier = imageIdentifiers.get(0);
+        return Character.toUpperCase(identifier.charAt(0)) + identifier.substring(1) + ":" + entry;
     }
 
     private Table buildTable(SpanManager sm, ContentElementParsingParameters cepp,

--- a/dkpro-jwpl-parser/src/test/java/org/dkpro/jwpl/parser/GalleryTest.java
+++ b/dkpro-jwpl-parser/src/test/java/org/dkpro/jwpl/parser/GalleryTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.jwpl.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.dkpro.jwpl.api.WikiConstants.Language;
+import org.dkpro.jwpl.parser.mediawiki.MediaWikiParser;
+import org.dkpro.jwpl.parser.mediawiki.MediaWikiParserFactory;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that the files listed in a {@code <gallery>} are parsed as images. The lines of a gallery
+ * name files without the namespace prefix a link outside a gallery needs, which used to make every
+ * one of them an internal link to an article of that name (see issue #151).
+ */
+class GalleryTest
+{
+
+    private static MediaWikiParser parserFor(Language language)
+    {
+        return new MediaWikiParserFactory(language).createParser();
+    }
+
+    @Test
+    void parsesTheEntriesOfAGalleryAsImages()
+    {
+        String text = """
+                A staircase.
+
+                == Gallery ==
+                <gallery heights="150" widths="150">
+                Jordantreppe Petersburg Eremitage 02.JPG
+                Hermitage staicase.jpg|The staircase seen from below
+                </gallery>
+                """;
+
+        List<Link> links = parserFor(Language.english).parse(text).getLinks();
+
+        assertEquals(2, links.size());
+        for (Link link : links) {
+            assertEquals(Link.type.IMAGE, link.getType(),
+                    "'" + link.getTarget() + "' is not parsed as an image");
+        }
+        assertEquals("Image:Jordantreppe_Petersburg_Eremitage_02.JPG", links.get(0).getTarget());
+        assertEquals("Image:Hermitage_staicase.jpg", links.get(1).getTarget());
+    }
+
+    @Test
+    void keepsTheNamespaceOfAnEntryThatCarriesOne()
+    {
+        String text = """
+                <gallery>
+                File:With prefix.jpg
+                Without prefix.jpg
+                </gallery>
+                """;
+
+        List<Link> links = parserFor(Language.english).parse(text).getLinks();
+
+        assertEquals(2, links.size());
+        assertEquals("File:With_prefix.jpg", links.get(0).getTarget());
+        assertEquals("Image:Without_prefix.jpg", links.get(1).getTarget());
+        assertTrue(links.stream().allMatch(l -> l.getType() == Link.type.IMAGE));
+    }
+
+    @Test
+    void prefixesTheEntriesOfAGalleryWithTheIdentifierOfTheLanguage()
+    {
+        String text = """
+                <gallery>
+                Ohne Präfix.jpg
+                Datei:Mit Präfix.jpg
+                </gallery>
+                """;
+
+        List<Link> links = parserFor(Language.german).parse(text).getLinks();
+
+        assertEquals(2, links.size());
+        assertEquals("Bild:Ohne_Präfix.jpg", links.get(0).getTarget());
+        assertEquals("Datei:Mit_Präfix.jpg", links.get(1).getTarget());
+        assertTrue(links.stream().allMatch(l -> l.getType() == Link.type.IMAGE));
+    }
+}


### PR DESCRIPTION
Prefixes the lines of a gallery with the configured image identifier unless they already carry one, so they are typed as images rather than as internal links to articles of that name. Fixes #151