### PR TITLE
#111: Separate template parameters only on the pipes that separate them

### DIFF
--- a/dkpro-jwpl-parser/src/main/java/org/dkpro/jwpl/parser/mediawiki/ModularParser.java
+++ b/dkpro-jwpl-parser/src/main/java/org/dkpro/jwpl/parser/mediawiki/ModularParser.java
@@ -891,7 +891,8 @@ public class ModularParser
 
             if (templateOptionTag != -1) {
                 templateNameEnd = templateOptionTag;
-                templateOptions = tokenize(sm, templateOptionTag + 1, templateCloseTag, SYMBOL_PIPE);
+                templateOptions = tokenizeTemplateParameters(sm, templateOptionTag + 1,
+                        templateCloseTag);
             }
             else {
                 templateNameEnd = templateCloseTag;
@@ -1205,6 +1206,78 @@ public class ModularParser
         parseContentElement(sm, cepp, paragraphSpans, result);
 
         return result;
+    }
+
+    /**
+     * Splits the parameters of a template on the pipes that separate them, which are the pipes
+     * outside of any link, template or table markup: a pipe inside {@code [[A|B]]} belongs to that
+     * link and is not a parameter separator, so splitting on every pipe cuts such a parameter in
+     * two (see issue #111).
+     *
+     * @param sm    The {@link SpanManager} holding the text.
+     * @param start The position of the first character behind the pipe that ends the template name.
+     * @param end   The position of the closing braces of the template.
+     * @return The parameters of the template, in the order in which they occur.
+     */
+    private List<String> tokenizeTemplateParameters(SpanManager sm, int start, int end)
+    {
+        List<String> result = new ArrayList<>();
+
+        if (start > end) {
+            logger.debug("tokenizeTemplateParameters({},{}) doesn't make sense", start, end);
+            return result;
+        }
+
+        int depth = 0;
+        int tokenStart = start;
+
+        for (int i = start; i < end; i++) {
+            char current = sm.charAt(i);
+            char next = i + 1 < end ? sm.charAt(i + 1) : 0;
+
+            // "[[" and "[" open a link, "{{" a template and "{|" a table
+            if (current == '[') {
+                if (next == '[') {
+                    i++;
+                }
+                depth++;
+            }
+            else if (current == '{' && (next == '{' || next == '|')) {
+                i++;
+                depth++;
+            }
+            else if (current == ']') {
+                if (next == ']') {
+                    i++;
+                }
+                depth = Math.max(0, depth - 1);
+            }
+            else if (current == '}' && next == '}') {
+                i++;
+                depth = Math.max(0, depth - 1);
+            }
+            else if (current == '|' && next == '}') {
+                // the end of a table, not a separator
+                i++;
+                depth = Math.max(0, depth - 1);
+            }
+            else if (current == '|' && depth == 0) {
+                addToken(result, sm, tokenStart, i);
+                tokenStart = i + 1;
+            }
+        }
+
+        addToken(result, sm, tokenStart, end);
+
+        return result;
+    }
+
+    private void addToken(List<String> tokens, SpanManager sm, int start, int end)
+    {
+        String token = sm.substring(start, end).trim();
+        if (!token.isEmpty()) {
+            tokens.add(token);
+        }
     }
 
     private List<String> tokenize(SpanManager sm, int start, int end, String delim)

--- a/dkpro-jwpl-parser/src/test/java/org/dkpro/jwpl/parser/TemplateParameterTest.java
+++ b/dkpro-jwpl-parser/src/test/java/org/dkpro/jwpl/parser/TemplateParameterTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.jwpl.parser;
+
+import static java.util.List.of;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.dkpro.jwpl.api.WikiConstants.Language;
+import org.dkpro.jwpl.parser.mediawiki.MediaWikiParser;
+import org.dkpro.jwpl.parser.mediawiki.MediaWikiParserFactory;
+import org.dkpro.jwpl.parser.mediawiki.ShowTemplateNamesAndParameters;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that the parameters of a template are separated on the pipes that actually separate them.
+ * A pipe inside a link, a nested template or a table belongs to that markup, and splitting on it
+ * cuts the parameter it occurs in into pieces (see issue #111).
+ */
+class TemplateParameterTest
+{
+
+    private static List<String> parametersOf(String text)
+    {
+        MediaWikiParserFactory factory = new MediaWikiParserFactory(Language.english);
+        factory.setTemplateParserClass(ShowTemplateNamesAndParameters.class);
+        MediaWikiParser parser = factory.createParser();
+
+        List<Template> templates = parser.parse(text).getTemplates();
+        assertEquals(1, templates.size(), "expected exactly one template in: " + text);
+        return templates.get(0).getParameters();
+    }
+
+    @Test
+    void keepsAParameterHoldingALinkWithAnAnchorTogether()
+    {
+        assertEquals(
+                of("region1name=[[Houston/Downtown|Downtown]]", "region1color=#d56d76"),
+                parametersOf("""
+                        {{Regionlist
+                        | region1name=[[Houston/Downtown|Downtown]]
+                        | region1color=#d56d76
+                        }}"""));
+    }
+
+    @Test
+    void keepsAParameterHoldingAnImageWithItsOptionsTogether()
+    {
+        assertEquals(of("image=[[File:X.jpg|thumb|left|A caption]]", "caption=Plain"),
+                parametersOf("{{Infobox|image=[[File:X.jpg|thumb|left|A caption]]|caption=Plain}}"));
+    }
+
+    @Test
+    void keepsAParameterHoldingATableTogether()
+    {
+        assertEquals(of("body={| class=\"wikitable\"\n! a !! b\n|-\n| 1 || 2\n|}", "footer=x"),
+                parametersOf("""
+                        {{Wrapper|body={| class="wikitable"
+                        ! a !! b
+                        |-
+                        | 1 || 2
+                        |}|footer=x}}"""));
+    }
+
+    @Test
+    void separatesTheParametersOfAPlainTemplate()
+    {
+        assertEquals(of("first", "second=2", "third"),
+                parametersOf("{{Simple|first|second=2|third}}"));
+    }
+}


### PR DESCRIPTION
Splits template parameters with a tokenizer that keeps track of the link, template and table markup it is inside, so that a parameter such as region1name=[[Houston/Downtown|Downtown]] is no longer cut in two. Fixes #111