### PR TITLE
#90: Return the target of a link that carries no caption

### DIFF
--- a/dkpro-jwpl-parser/src/main/java/org/dkpro/jwpl/parser/Link.java
+++ b/dkpro-jwpl-parser/src/main/java/org/dkpro/jwpl/parser/Link.java
@@ -91,14 +91,21 @@ public class Link
     }
 
     /**
-     * Retruns the Link text or link caption.
+     * Returns the link text or link caption. Where a link carries no caption of its own, the
+     * target is returned instead: the text behind the pipe of a category link is its sort key
+     * rather than a caption, and {@code [[Category:Anarchism| ]]} would otherwise be the empty
+     * string (see issue #90).
+     *
+     * @return The caption of the link, or its target if the link has no caption.
      */
     public String getText()
     {
         if (home_cc == null) {
             return null;
         }
-        return pos.getText(home_cc.getText());
+
+        String text = pos.getText(home_cc.getText());
+        return text == null || text.isBlank() ? target : text;
     }
 
     /**

--- a/dkpro-jwpl-parser/src/main/java/org/dkpro/jwpl/parser/Link.java
+++ b/dkpro-jwpl-parser/src/main/java/org/dkpro/jwpl/parser/Link.java
@@ -91,12 +91,14 @@ public class Link
     }
 
     /**
-     * Returns the link text or link caption. Where a link carries no caption of its own, the
-     * target is returned instead: the text behind the pipe of a category link is its sort key
-     * rather than a caption, and {@code [[Category:Anarchism| ]]} would otherwise be the empty
-     * string (see issue #90).
+     * Returns the link text or link caption. Where that text is blank, the target is returned
+     * instead (see issue #90).
+     * <p>
+     * For a category link, the text behind the pipe is its sort key. A sort key that is not
+     * blank, as in {@code [[Category:Anarchism|Anarchism, political]]}, is returned as is, while
+     * a blank one, as in {@code [[Category:Anarchism| ]]}, yields the target.
      *
-     * @return The caption of the link, or its target if the link has no caption.
+     * @return The text of the link, or its target if that text is blank.
      */
     public String getText()
     {

--- a/dkpro-jwpl-parser/src/test/java/org/dkpro/jwpl/parser/LinkTextTest.java
+++ b/dkpro-jwpl-parser/src/test/java/org/dkpro/jwpl/parser/LinkTextTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.jwpl.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.dkpro.jwpl.api.WikiConstants.Language;
+import org.dkpro.jwpl.parser.mediawiki.MediaWikiParser;
+import org.dkpro.jwpl.parser.mediawiki.MediaWikiParserFactory;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link Link#getText()} for links that carry no caption of their own. The text behind the
+ * pipe of a category link is its sort key, and a sort key of a single space used to leave the
+ * caption empty (see issue #90).
+ */
+class LinkTextTest
+{
+
+    private static MediaWikiParser parser()
+    {
+        return new MediaWikiParserFactory(Language.english).createParser();
+    }
+
+    @Test
+    void returnsTheTargetOfACategoryLinkWhoseSortKeyIsEmpty()
+    {
+        String text = """
+                Anarchism is a political philosophy.
+
+                [[Category:Anarchism| ]]
+                [[Category:Political culture]]
+                """;
+
+        List<Link> categories = parser().parse(text).getCategories();
+
+        assertEquals(2, categories.size());
+        assertEquals("Category:Anarchism", categories.get(0).getText());
+        assertEquals("Category:Political culture", categories.get(1).getText());
+    }
+
+    @Test
+    void returnsTheTargetOfACategoryLinkWithASortKey()
+    {
+        List<Link> categories = parser().parse("[[Category:Anarchism|Anarchism, political]]")
+                .getCategories();
+
+        assertEquals(1, categories.size());
+        // a sort key that is not empty is still reported as the text of the link
+        assertEquals("Anarchism, political", categories.get(0).getText());
+    }
+
+    @Test
+    void keepsTheCaptionOfALinkThatHasOne()
+    {
+        List<Link> links = parser().parse("An [[anchor link|internal link]] here.").getLinks();
+
+        assertEquals(1, links.size());
+        assertEquals("internal link", links.get(0).getText());
+    }
+
+    @Test
+    void returnsTheTargetOfALinkWithoutACaption()
+    {
+        List<Link> links = parser().parse("An [[internal link]] here.").getLinks();
+
+        assertEquals(1, links.size());
+        assertEquals("internal link", links.get(0).getText());
+    }
+}


### PR DESCRIPTION
Falls back to the target of a link when its caption is empty, so that a category link with a blank sort key such as [[Category:Anarchism| ]] no longer reports an empty text. Fixes #90