### PR TITLE
#79: Add a method returning all outlink anchors

### DIFF
--- a/dkpro-jwpl-parser/src/main/java/org/dkpro/jwpl/parser/LinkAnchorExtractor.java
+++ b/dkpro-jwpl-parser/src/main/java/org/dkpro/jwpl/parser/LinkAnchorExtractor.java
@@ -82,18 +82,50 @@ public class LinkAnchorExtractor
 
     /**
      * Note that this method only returns the anchors that are not equal to the title of the page
-     * they are pointing to. Anchors might contain references to sections in an article in the form
-     * of "Page#Section". If you need the plain title, e.g. for checking whether the page exists in
+     * they are pointing to. Use {@link #getAllOutlinkAnchors(Page)} to obtain every anchor,
+     * including those. Anchors might contain references to sections in an article in the form of
+     * "Page#Section". If you need the plain title, e.g. for checking whether the page exists in
      * Wikipedia, the Title object can be used.
      *
+     * @param page The page whose outgoing links are inspected.
      * @return A mapping from the page titles of links in that page to the anchor texts used in the
      *         links.
-     * @throws WikiTitleParsingException
+     * @throws WikiTitleParsingException Thrown if a link target could not be parsed as a title.
      */
     public Map<String, Set<String>> getOutlinkAnchors(Page page) throws WikiTitleParsingException
     {
+        return getOutlinkAnchors(parser.parse(page.getText()), false);
+    }
+
+    /**
+     * Returns every anchor text of the outgoing links of a page, including the anchors that are
+     * equal to the title of the page they are pointing to. How often a given anchor is used for a
+     * given page is what word sense disambiguation reads out of a Wikipedia, and dropping the
+     * anchors that repeat the title removes the most frequent sense of most words from that count
+     * (see issue #79).
+     *
+     * @param page The page whose outgoing links are inspected.
+     * @return A mapping from the page titles of links in that page to the anchor texts used in the
+     *         links.
+     * @throws WikiTitleParsingException Thrown if a link target could not be parsed as a title.
+     */
+    public Map<String, Set<String>> getAllOutlinkAnchors(Page page) throws WikiTitleParsingException
+    {
+        return getOutlinkAnchors(parser.parse(page.getText()), true);
+    }
+
+    /**
+     * @param pp                         The parsed page whose outgoing links are inspected.
+     * @param includeAnchorsEqualToTitle Whether an anchor that is equal to the title of the page it
+     *                                   points to is part of the result.
+     * @return A mapping from the page titles of links in that page to the anchor texts used in the
+     *         links.
+     * @throws WikiTitleParsingException Thrown if a link target could not be parsed as a title.
+     */
+    Map<String, Set<String>> getOutlinkAnchors(ParsedPage pp, boolean includeAnchorsEqualToTitle)
+        throws WikiTitleParsingException
+    {
         Map<String, Set<String>> outAnchors = new HashMap<>();
-        ParsedPage pp = parser.parse(page.getText());
         if (pp == null) {
             return outAnchors;
         }
@@ -109,16 +141,9 @@ public class LinkAnchorExtractor
             // are categories or other metadata
             {
                 String anchorText = l.getText();
-                if (!anchorText.equals(targetTitle)) {
-                    Set<String> anchors;
-                    if (outAnchors.containsKey(targetTitle)) {
-                        anchors = outAnchors.get(targetTitle);
-                    }
-                    else {
-                        anchors = new HashSet<>();
-                    }
-                    anchors.add(anchorText);
-                    outAnchors.put(targetTitle, anchors);
+                if (includeAnchorsEqualToTitle || !anchorText.equals(targetTitle)) {
+                    outAnchors.computeIfAbsent(targetTitle, title -> new HashSet<>())
+                            .add(anchorText);
                 }
             }
         }

--- a/dkpro-jwpl-parser/src/test/java/org/dkpro/jwpl/parser/LinkAnchorExtractorTest.java
+++ b/dkpro-jwpl-parser/src/test/java/org/dkpro/jwpl/parser/LinkAnchorExtractorTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.jwpl.parser;
+
+import static java.util.Set.of;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.dkpro.jwpl.api.WikiConstants.Language;
+import org.dkpro.jwpl.api.exception.WikiTitleParsingException;
+import org.dkpro.jwpl.parser.mediawiki.MediaWikiParser;
+import org.dkpro.jwpl.parser.mediawiki.MediaWikiParserFactory;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the anchor texts {@link LinkAnchorExtractor} reads out of the outgoing links of a page,
+ * with and without the anchors that repeat the title of the page they point to (see issue #79).
+ */
+class LinkAnchorExtractorTest
+{
+
+    private static final String TEXT = """
+            The [[Wikipedia]] is written by volunteers, and the [[Wikipedia|free encyclopedia]]
+            is what [[Wikipedia|it]] calls itself. See also the [[Nupedia]].
+            """;
+
+    private static final MediaWikiParser PARSER = new MediaWikiParserFactory(Language.english)
+            .createParser();
+
+    private static final LinkAnchorExtractor EXTRACTOR = new LinkAnchorExtractor(PARSER);
+
+    private static Map<String, Set<String>> anchorsOf(boolean includeAnchorsEqualToTitle)
+        throws WikiTitleParsingException
+    {
+        return EXTRACTOR.getOutlinkAnchors(PARSER.parse(TEXT), includeAnchorsEqualToTitle);
+    }
+
+    @Test
+    void returnsEveryAnchorIncludingTheOnesEqualToTheTitle() throws Exception
+    {
+        Map<String, Set<String>> anchors = anchorsOf(true);
+
+        assertEquals(of("Wikipedia", "free encyclopedia", "it"), anchors.get("Wikipedia"));
+        assertEquals(of("Nupedia"), anchors.get("Nupedia"));
+    }
+
+    @Test
+    void dropsTheAnchorsEqualToTheTitle() throws Exception
+    {
+        Map<String, Set<String>> anchors = anchorsOf(false);
+
+        assertEquals(of("free encyclopedia", "it"), anchors.get("Wikipedia"));
+        // 'Nupedia' is linked by its title only, so it has no anchor left at all
+        assertTrue(anchors.get("Nupedia") == null || anchors.get("Nupedia").isEmpty());
+    }
+}


### PR DESCRIPTION
Adds LinkAnchorExtractor.getAllOutlinkAnchors(), which keeps the anchors that are equal to the title of the page they point to, as word sense disambiguation needs those counts. Fixes #79