### PR TITLE
#3: Add the number of pages matching a PageQuery

### DIFF
--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/PageQueryIterable.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/PageQueryIterable.java
@@ -185,4 +185,15 @@ public class PageQueryIterable
     {
         return new PageQueryIterator(wiki, pageIdList);
     }
+
+    /**
+     * The pages matching the query are selected when this object is created, so their number is
+     * known without iterating over them.
+     *
+     * @return The number of pages that match the query.
+     */
+    public int size()
+    {
+        return pageIdList.size();
+    }
 }

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Wikipedia.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Wikipedia.java
@@ -677,6 +677,19 @@ public class Wikipedia
     }
 
     /**
+     * Get the number of pages that match the given query. The query is evaluated the same way as
+     * in {@link #getPages(PageQuery)}, which means the same warning applies: it may be running very
+     * slow, depending on the size of the Wikipedia!
+     *
+     * @param query A query object containing the query conditions.
+     * @return The number of pages that match the given query.
+     * @throws WikiApiException Thrown if errors occurred.
+     */
+    public int getNumberOfPages(PageQuery query) throws WikiApiException {
+        return new PageQueryIterable(this, query).size();
+    }
+
+    /**
      * Get all articles (pages MINUS disambiguationPages MINUS redirects). Returns only an iterable,
      * as a collection may not fit into memory for a large wikipedia.
      *

--- a/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/PageQueryIterableTest.java
+++ b/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/PageQueryIterableTest.java
@@ -63,6 +63,29 @@ public class PageQueryIterableTest
         assertNotNull(pqi);
     }
 
+    @Test
+    public void testNumberOfPagesOfAQueryWithoutConditions() throws WikiApiException
+    {
+        assertEquals(34, new PageQueryIterable(wiki, pq).size());
+        assertEquals(34, wiki.getNumberOfPages(pq));
+    }
+
+    @Test
+    public void testNumberOfPagesMatchesTheNumberOfIteratedPages() throws WikiApiException
+    {
+        pq.setTitlePattern("Wikipedia%");
+        pq.setOnlyArticlePages(true);
+
+        int iterated = 0;
+        for (Page page : wiki.getPages(pq)) {
+            assertNotNull(page);
+            iterated++;
+        }
+
+        assertTrue(iterated >= 1);
+        assertEquals(iterated, wiki.getNumberOfPages(pq));
+    }
+
     // Example with ' character in titlePattern verifies issue #124
     @ParameterizedTest
     @ValueSource(strings = {"Wikipedia%", "Wiki_edia%", "Moore'%"})


### PR DESCRIPTION
Exposes the number of pages a PageQuery matches through PageQueryIterable.size() and Wikipedia.getNumberOfPages(PageQuery), so callers no longer have to iterate over the whole result to count it. Fixes #3