### PR TITLE
#105: Derive the input type of a dump from its file extension

### DIFF
--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/config/gui/dialogs/InputDialog.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/config/gui/dialogs/InputDialog.java
@@ -27,6 +27,8 @@ import javax.swing.JFileChooser;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 
 import org.dkpro.jwpl.revisionmachine.difftool.config.gui.control.ConfigController;
 import org.dkpro.jwpl.revisionmachine.difftool.config.gui.control.ConfigSettings;
@@ -89,6 +91,26 @@ public class InputDialog
 
             pathField = new JTextField();
             pathField.setBounds(10, 40, 250, 25);
+            pathField.getDocument().addDocumentListener(new DocumentListener()
+            {
+                @Override
+                public void insertUpdate(DocumentEvent e)
+                {
+                    selectTypeOfCurrentPath();
+                }
+
+                @Override
+                public void removeUpdate(DocumentEvent e)
+                {
+                    selectTypeOfCurrentPath();
+                }
+
+                @Override
+                public void changedUpdate(DocumentEvent e)
+                {
+                    selectTypeOfCurrentPath();
+                }
+            });
             this.add(pathField);
 
             searchButton = new JButton("Search");
@@ -103,6 +125,28 @@ public class InputDialog
             });
 
             this.add(searchButton);
+        }
+
+        /**
+         * Selects the input type that matches the extension of the entered path, so that a
+         * compressed dump is not processed as an uncompressed one just because the type was left
+         * at its default (see issue #105). A type the extension does not identify, and one that is
+         * not offered by the chooser, leaves the current selection alone, so it can still be set by
+         * hand.
+         */
+        private void selectTypeOfCurrentPath()
+        {
+            InputType type = InputType.fromPath(pathField.getText());
+            if (type == null || typeChooser == null) {
+                return;
+            }
+
+            for (int i = 0; i < typeChooser.getItemCount(); i++) {
+                if (typeChooser.getItemAt(i) == type) {
+                    typeChooser.setSelectedItem(type);
+                    return;
+                }
+            }
         }
 
         /**

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/data/archive/InputType.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/data/archive/InputType.java
@@ -59,4 +59,33 @@ public enum InputType
         };
 
     }
+
+    /**
+     * Derives the InputType of a dump from the extension of its file name. Setting the type by
+     * hand is easily overlooked, and a compressed dump left at the default of an uncompressed one
+     * fails only once the DiffTool is running (see issue #105).
+     *
+     * @param path
+     *            The path or name of a dump file. May be {@code null}.
+     * @return The InputType matching the extension of the file, or {@code null} if the extension
+     *         does not identify one of the supported types.
+     */
+    public static InputType fromPath(final String path)
+    {
+        if (path == null) {
+            return null;
+        }
+
+        String name = path.trim().toLowerCase();
+        if (name.endsWith(".bz2")) {
+            return BZIP2;
+        }
+        if (name.endsWith(".7z")) {
+            return SEVENZIP;
+        }
+        if (name.endsWith(".xml")) {
+            return XML;
+        }
+        return null;
+    }
 }

--- a/dkpro-jwpl-revisionmachine/src/test/java/org/dkpro/jwpl/revisionmachine/difftool/data/archive/InputTypeTest.java
+++ b/dkpro-jwpl-revisionmachine/src/test/java/org/dkpro/jwpl/revisionmachine/difftool/data/archive/InputTypeTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.jwpl.revisionmachine.difftool.data.archive;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests {@link InputType}, most of all the type a dump file name implies (see issue #105).
+ */
+class InputTypeTest
+{
+
+    @ParameterizedTest
+    @CsvSource({ //
+            "dewiki-20250201-pages-meta-history.xml, XML", //
+            "dewiki-20250201-pages-meta-history.xml.bz2, BZIP2", //
+            "dewiki-20250201-pages-meta-history.xml.7z, SEVENZIP", //
+            "/data/dumps/DEWIKI.XML.BZ2, BZIP2", //
+            "  spaced.7z  , SEVENZIP" })
+    void derivesTheTypeFromTheExtension(String path, InputType expected)
+    {
+        assertEquals(expected, InputType.fromPath(path));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = { "dump", "dump.gz", "dump.zip", "dump.xml.gz", ".xmlish" })
+    void reportsNoTypeForAnExtensionItDoesNotKnow(String path)
+    {
+        assertNull(InputType.fromPath(path));
+    }
+
+    @Test
+    void parsesTheStringRepresentation()
+    {
+        assertEquals(InputType.XML, InputType.parse("xml"));
+        assertEquals(InputType.BZIP2, InputType.parse("BZIP2"));
+        assertEquals(InputType.SEVENZIP, InputType.parse("SevenZip"));
+        assertThrows(IllegalArgumentException.class, () -> InputType.parse("gzip"));
+    }
+}


### PR DESCRIPTION
Preselects the input type in the ConfigGUI from the extension of the dump file (.xml, .bz2, .7z), so a compressed dump is no longer processed as an uncompressed one because the type was left at its default. Fixes #105