### PR TITLE
#14: Join configured paths and file names with one separator

### DIFF
--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/common/logging/Logger.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/common/logging/Logger.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import org.dkpro.jwpl.revisionmachine.common.exceptions.ErrorFactory;
 import org.dkpro.jwpl.revisionmachine.common.exceptions.ErrorKeys;
 import org.dkpro.jwpl.revisionmachine.common.exceptions.LoggingException;
+import org.dkpro.jwpl.revisionmachine.common.util.FilePaths;
 import org.dkpro.jwpl.revisionmachine.difftool.config.ConfigurationKeys;
 import org.dkpro.jwpl.revisionmachine.difftool.config.ConfigurationManager;
 import org.slf4j.LoggerFactory;
@@ -96,7 +97,7 @@ public class Logger
                         .createLoggingException(ErrorKeys.LOGGING_LOGGER_INITIALIZISATION_FAILED);
             }
 
-            this.writer = new FileWriter(path + consumerName + ".log");
+            this.writer = new FileWriter(FilePaths.resolve(path, consumerName + ".log"));
 
         }
         catch (Exception e) {

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/common/util/FilePaths.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/common/util/FilePaths.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.jwpl.revisionmachine.common.util;
+
+import java.io.File;
+
+/**
+ * Joins the path fragments of a configuration with the file names built from them.
+ * <p>
+ * The ConfigGUI appends a trailing separator to every directory it writes, but a configuration
+ * written by hand needs not, and appending a file name to such a directory used to produce a path
+ * like {@code /data/dumpsdewiki.sql} (see issue #14).
+ */
+public final class FilePaths
+{
+
+    private FilePaths()
+    {
+        // static-only
+    }
+
+    /**
+     * Joins path fragments, inserting the separator of the platform between two fragments that
+     * carry none and collapsing the separators where both of them carry one. A fragment that is
+     * {@code null} or empty is skipped, so a configuration that leaves an optional sub directory
+     * empty yields the path without it.
+     *
+     * @param first The first fragment, typically a directory from the configuration.
+     * @param more  The remaining fragments, of which the last is typically a file name.
+     * @return The joined path.
+     */
+    public static String resolve(String first, String... more)
+    {
+        StringBuilder path = new StringBuilder(first == null ? "" : first);
+        for (String fragment : more) {
+            if (fragment == null || fragment.isEmpty()) {
+                continue;
+            }
+            int from = 0;
+            if (path.isEmpty()) {
+                // nothing to join to yet, so the fragment is the start of the path
+            }
+            else if (endsWithSeparator(path)) {
+                // skip the separators the fragment carries, rather than doubling them
+                while (from < fragment.length() && isSeparator(fragment.charAt(from))) {
+                    from++;
+                }
+            }
+            else if (!startsWithSeparator(fragment)) {
+                path.append(File.separatorChar);
+            }
+            path.append(fragment, from, fragment.length());
+        }
+        return path.toString();
+    }
+
+    private static boolean endsWithSeparator(CharSequence path)
+    {
+        return isSeparator(path.charAt(path.length() - 1));
+    }
+
+    private static boolean startsWithSeparator(String fragment)
+    {
+        return isSeparator(fragment.charAt(0));
+    }
+
+    private static boolean isSeparator(char c)
+    {
+        // a configuration written on one platform is regularly read on the other
+        return c == File.separatorChar || c == '/' || c == '\\';
+    }
+}

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/diff/calculation/DiffCalculator.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/diff/calculation/DiffCalculator.java
@@ -30,6 +30,7 @@ import org.dkpro.jwpl.revisionmachine.common.exceptions.DiffException;
 import org.dkpro.jwpl.revisionmachine.common.exceptions.ErrorFactory;
 import org.dkpro.jwpl.revisionmachine.common.exceptions.ErrorKeys;
 import org.dkpro.jwpl.revisionmachine.common.exceptions.TimeoutException;
+import org.dkpro.jwpl.revisionmachine.common.util.FilePaths;
 import org.dkpro.jwpl.revisionmachine.common.util.Surrogates;
 import org.dkpro.jwpl.revisionmachine.common.util.WikipediaXMLWriter;
 import org.dkpro.jwpl.revisionmachine.difftool.config.ConfigurationKeys;
@@ -515,8 +516,9 @@ public class DiffCalculator
 
                             if (MODE_DEBUG_OUTPUT_ACTIVATED) {
                                 WikipediaXMLWriter writer = new WikipediaXMLWriter(
-                                        LOGGING_PATH_DIFFTOOL + LOGGING_PATH_DEBUG
-                                                + task.getHeader().getArticleName() + ".dbg");
+                                        FilePaths.resolve(LOGGING_PATH_DIFFTOOL,
+                                                LOGGING_PATH_DEBUG,
+                                                task.getHeader().getArticleName() + ".dbg"));
 
                                 writer.writeRevision(task);
                                 writer.close();

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/dump/codec/SQLEncoder.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/dump/codec/SQLEncoder.java
@@ -29,6 +29,7 @@ import org.dkpro.jwpl.revisionmachine.common.exceptions.ErrorKeys;
 import org.dkpro.jwpl.revisionmachine.common.exceptions.SQLConsumerException;
 import org.dkpro.jwpl.revisionmachine.common.logging.Logger;
 import org.dkpro.jwpl.revisionmachine.common.logging.messages.consumer.ConsumerLogMessages;
+import org.dkpro.jwpl.revisionmachine.common.util.FilePaths;
 import org.dkpro.jwpl.revisionmachine.common.util.Surrogates;
 import org.dkpro.jwpl.revisionmachine.common.util.WikipediaXMLWriter;
 import org.dkpro.jwpl.revisionmachine.difftool.config.ConfigurationKeys;
@@ -439,8 +440,9 @@ public class SQLEncoder
 
                 try {
 
-                    WikipediaXMLWriter writer = new WikipediaXMLWriter(LOGGING_PATH_DIFFTOOL
-                            + LOGGING_PATH_DEBUG + task.getHeader().getArticleName() + ".dbg");
+                    WikipediaXMLWriter writer = new WikipediaXMLWriter(
+                            FilePaths.resolve(LOGGING_PATH_DIFFTOOL, LOGGING_PATH_DEBUG,
+                                    task.getHeader().getArticleName() + ".dbg"));
 
                     switch (task.getTaskType()) {
                     case TASK_FULL:

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/dump/writer/DataFileArchiveWriter.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/dump/writer/DataFileArchiveWriter.java
@@ -29,6 +29,7 @@ import org.dkpro.jwpl.revisionmachine.common.exceptions.ErrorFactory;
 import org.dkpro.jwpl.revisionmachine.common.exceptions.ErrorKeys;
 import org.dkpro.jwpl.revisionmachine.common.exceptions.LoggingException;
 import org.dkpro.jwpl.revisionmachine.common.exceptions.SQLConsumerException;
+import org.dkpro.jwpl.revisionmachine.common.util.FilePaths;
 import org.dkpro.jwpl.revisionmachine.difftool.config.ConfigurationKeys;
 import org.dkpro.jwpl.revisionmachine.difftool.config.ConfigurationManager;
 import org.dkpro.jwpl.revisionmachine.difftool.consumer.dump.WriterInterface;
@@ -221,7 +222,8 @@ public class DataFileArchiveWriter
         }
         this.counter++;
 
-        String filePath = PATH_OUTPUT_SQL_FILES + this.outputName + "_" + counter;
+        String filePath = FilePaths.resolve(PATH_OUTPUT_SQL_FILES,
+                this.outputName + "_" + counter);
         this.output = OutputFactory.getOutputStream(filePath);
         this.dataArchive = new File(filePath);
         this.output.flush();

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/dump/writer/DataFileWriter.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/dump/writer/DataFileWriter.java
@@ -33,6 +33,7 @@ import org.dkpro.jwpl.revisionmachine.common.exceptions.ErrorFactory;
 import org.dkpro.jwpl.revisionmachine.common.exceptions.ErrorKeys;
 import org.dkpro.jwpl.revisionmachine.common.exceptions.LoggingException;
 import org.dkpro.jwpl.revisionmachine.common.exceptions.SQLConsumerException;
+import org.dkpro.jwpl.revisionmachine.common.util.FilePaths;
 import org.dkpro.jwpl.revisionmachine.difftool.config.ConfigurationKeys;
 import org.dkpro.jwpl.revisionmachine.difftool.config.ConfigurationManager;
 import org.dkpro.jwpl.revisionmachine.difftool.consumer.dump.WriterInterface;
@@ -227,7 +228,8 @@ public class DataFileWriter
         }
 
         this.fileCounter++;
-        String filePath = PATH_OUTPUT_DATA_FILES + this.outputName + "_" + fileCounter + ".csv";
+        String filePath = FilePaths.resolve(PATH_OUTPUT_DATA_FILES,
+                this.outputName + "_" + fileCounter + ".csv");
         this.dataFile = new File(filePath);
         this.writer = new BufferedWriter(new OutputStreamWriter(
                 new BufferedOutputStream(new FileOutputStream(filePath)), WIKIPEDIA_ENCODING));

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/dump/writer/SQLArchiveWriter.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/dump/writer/SQLArchiveWriter.java
@@ -30,6 +30,7 @@ import org.dkpro.jwpl.revisionmachine.common.exceptions.LoggingException;
 import org.dkpro.jwpl.revisionmachine.common.exceptions.SQLConsumerException;
 import org.dkpro.jwpl.revisionmachine.common.logging.Logger;
 import org.dkpro.jwpl.revisionmachine.common.logging.messages.consumer.SQLConsumerLogMessages;
+import org.dkpro.jwpl.revisionmachine.common.util.FilePaths;
 import org.dkpro.jwpl.revisionmachine.difftool.config.ConfigurationKeys;
 import org.dkpro.jwpl.revisionmachine.difftool.config.ConfigurationManager;
 import org.dkpro.jwpl.revisionmachine.difftool.consumer.dump.WriterInterface;
@@ -245,7 +246,8 @@ public class SQLArchiveWriter
 
         this.counter++;
 
-        String filePath = PATH_OUTPUT_SQL_FILES + this.outputName + "_" + counter;
+        String filePath = FilePaths.resolve(PATH_OUTPUT_SQL_FILES,
+                this.outputName + "_" + counter);
 
         this.output = OutputFactory.getOutputStream(filePath);
 

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/dump/writer/SQLFileWriter.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/dump/writer/SQLFileWriter.java
@@ -34,6 +34,7 @@ import org.dkpro.jwpl.revisionmachine.common.exceptions.LoggingException;
 import org.dkpro.jwpl.revisionmachine.common.exceptions.SQLConsumerException;
 import org.dkpro.jwpl.revisionmachine.common.logging.Logger;
 import org.dkpro.jwpl.revisionmachine.common.logging.messages.consumer.SQLConsumerLogMessages;
+import org.dkpro.jwpl.revisionmachine.common.util.FilePaths;
 import org.dkpro.jwpl.revisionmachine.difftool.config.ConfigurationKeys;
 import org.dkpro.jwpl.revisionmachine.difftool.config.ConfigurationManager;
 import org.dkpro.jwpl.revisionmachine.difftool.consumer.dump.WriterInterface;
@@ -238,7 +239,8 @@ public class SQLFileWriter
         }
 
         this.fileCounter++;
-        String filePath = PATH_OUTPUT_SQL_FILES + this.outputName + "_" + fileCounter + ".sql";
+        String filePath = FilePaths.resolve(PATH_OUTPUT_SQL_FILES,
+                this.outputName + "_" + fileCounter + ".sql");
 
         SQLConsumerLogMessages.logFileCreation(logger, filePath);
 

--- a/dkpro-jwpl-revisionmachine/src/test/java/org/dkpro/jwpl/revisionmachine/common/util/FilePathsTest.java
+++ b/dkpro-jwpl-revisionmachine/src/test/java/org/dkpro/jwpl/revisionmachine/common/util/FilePathsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.jwpl.revisionmachine.common.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that a directory from a configuration and a generated file name are joined with exactly
+ * one separator, whether or not the configuration ends in one (see issue #14).
+ */
+class FilePathsTest
+{
+
+    private static final String SEP = File.separator;
+
+    @Test
+    void insertsTheSeparatorAConfigurationDoesNotCarry()
+    {
+        assertEquals("out" + SEP + "dewiki_1.sql", FilePaths.resolve("out", "dewiki_1.sql"));
+    }
+
+    @Test
+    void keepsTheSeparatorAConfigurationDoesCarry()
+    {
+        assertEquals("out" + SEP + "dewiki_1.sql",
+                FilePaths.resolve("out" + SEP, "dewiki_1.sql"));
+    }
+
+    @Test
+    void doesNotDoubleASeparatorTheFragmentCarries()
+    {
+        assertEquals("out" + SEP + "dewiki_1.sql",
+                FilePaths.resolve("out" + SEP, SEP + "dewiki_1.sql"));
+        assertEquals("out" + SEP + "dewiki_1.sql", FilePaths.resolve("out", SEP + "dewiki_1.sql"));
+    }
+
+    @Test
+    void acceptsTheSeparatorOfTheOtherPlatform()
+    {
+        assertEquals("out/dewiki_1.sql", FilePaths.resolve("out/", "dewiki_1.sql"));
+        assertEquals("out\\dewiki_1.sql", FilePaths.resolve("out\\", "dewiki_1.sql"));
+    }
+
+    @Test
+    void joinsMoreThanTwoFragments()
+    {
+        assertEquals("log" + SEP + "debug" + SEP + "Anarchism.dbg",
+                FilePaths.resolve("log", "debug", "Anarchism.dbg"));
+        assertEquals("log" + SEP + "debug" + SEP + "Anarchism.dbg",
+                FilePaths.resolve("log" + SEP, "debug" + SEP, "Anarchism.dbg"));
+    }
+
+    @Test
+    void skipsFragmentsThatAreEmptyOrAbsent()
+    {
+        assertEquals("log" + SEP + "Anarchism.dbg",
+                FilePaths.resolve("log", "", "Anarchism.dbg"));
+        assertEquals("log" + SEP + "Anarchism.dbg",
+                FilePaths.resolve("log", null, "Anarchism.dbg"));
+        assertEquals("Anarchism.dbg", FilePaths.resolve("", "Anarchism.dbg"));
+        assertEquals("Anarchism.dbg", FilePaths.resolve(null, "Anarchism.dbg"));
+    }
+}


### PR DESCRIPTION
Routes the places that build a file path from a configured directory through FilePaths.resolve(), so a configuration whose path lacks a trailing separator no longer produces paths like /data/dumpsdewiki_1.sql. Fixes #14