### PR TITLE
No issue: Fix broken Maven Central links

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -11,26 +11,26 @@
 - version: 2.0.2
   date: 2026-02-03
   status: stable
-  groupId: dkpro-jwpl
-  artifactId: org.dkpro.jwpl
+  groupId: org.dkpro.jwpl
+  artifactId: dkpro-jwpl
 
 - version: 2.0.1
   date: 2025-09-19
   status: stable
-  groupId: dkpro-jwpl
-  artifactId: org.dkpro.jwpl
+  groupId: org.dkpro.jwpl
+  artifactId: dkpro-jwpl
 
 - version: 2.0.0
   date: 2023-11-24
   status: stable
-  groupId: dkpro-jwpl
-  artifactId: org.dkpro.jwpl
+  groupId: org.dkpro.jwpl
+  artifactId: dkpro-jwpl
 
 - version: 2.0.3-SNAPSHOT
   date: unknown
   status: unstable
-  groupId: dkpro-jwpl
-  artifactId: org.dkpro.jwpl
+  groupId: org.dkpro.jwpl
+  artifactId: dkpro-jwpl
 
 - version: 1.1.0
   date: 2016-04-25

--- a/pages/DeveloperSetup.md
+++ b/pages/DeveloperSetup.md
@@ -8,7 +8,7 @@ permalink: "/DeveloperSetup/"
 
 # Maven Setup
 
-As of version 0.7.0, all JWPL components are available on [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Corg.dkpro.jwpl.wikipedia). If you use Maven as your build tool, then you can add any JWPL component as a dependency to your `pom.xml` without having to perform any additional configuration:
+As of version 0.7.0, all JWPL components are available on [Maven Central](https://central.sonatype.com/namespace/org.dkpro.jwpl). If you use Maven as your build tool, then you can add any JWPL component as a dependency to your `pom.xml` without having to perform any additional configuration:
 
 For adding JWPL components in the most recent version to your Maven project, add any of the following dependencies to your `pom.xml`:
 

--- a/pages/HowToGetJWPL.md
+++ b/pages/HowToGetJWPL.md
@@ -17,4 +17,4 @@ If you cannot or do not want to use Maven, can obtain "jars-with-dependencies" f
 ## Run JWPL components from the command line
 _Please not that fatjars are only available for JWPL versions up to 1.0.0._
 
-If you want to run JWPL components directly from the command line (e.g. the DataMachine), you should use the fatjars that come with all third-party libraries directly built-in. These jars can be downloaded from [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Corg.dkpro.jwpl.wikipedia). Choose the JWPL component you want to use and download the respective "jar-with-dependencies.jar".
+If you want to run JWPL components directly from the command line (e.g. the DataMachine), you should use the fatjars that come with all third-party libraries directly built-in. These jars can be downloaded from [Maven Central](https://central.sonatype.com/namespace/de.tudarmstadt.ukp.wikipedia). Choose the JWPL component you want to use and download the respective "jar-with-dependencies.jar".

--- a/pages/downloads.md
+++ b/pages/downloads.md
@@ -41,6 +41,6 @@ A full list of artifacts is available from [Maven Central][1]!
 
 Get the sources from [GitHub](https://github.com/dkpro/dkpro-jwpl/releases/tag/dkpro-jwpl-{{ stable.version }}).
 
-[1]: http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22{{ stable.groupId }}%22%20AND%20v%3A%22{{ stable.version }}%22
+[1]: https://central.sonatype.com/namespace/{{ stable.groupId }}
 
 


### PR DESCRIPTION
- Swap `groupId`/`artifactId` back for the 2.x releases in `_data/releases.yml`. They were reversed, which broke the sidebar badge link and the dependency snippet on the downloads page.
- Replace the retired `search.maven.org/#search` links with `central.sonatype.com` namespace pages.