### PR TITLE
No issue: Stop using the deprecated OS utility

### DIFF
--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/CategoryGraph.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/CategoryGraph.java
@@ -42,7 +42,6 @@ import org.dkpro.jwpl.api.exception.WikiTitleParsingException;
 import org.dkpro.jwpl.api.util.ApiUtilities;
 import org.dkpro.jwpl.api.util.CommonUtilities;
 import org.dkpro.jwpl.api.util.GraphSerialization;
-import org.dkpro.jwpl.api.util.OS;
 import org.jgrapht.GraphPath;
 import org.jgrapht.alg.connectivity.ConnectivityInspector;
 import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
@@ -300,7 +299,6 @@ public class CategoryGraph
         numberOfNodes = graph.vertexSet().size();
 
         // add edges
-        logger.info("{} MB memory used.", OS.getUsedMemory());
         int progress = 0;
         for (int pageID : graph.vertexSet()) {
             progress++;

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/util/ApiUtilities.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/util/ApiUtilities.java
@@ -71,7 +71,9 @@ public class ApiUtilities
             double progressPercent = (double) (counter * 100) / size;
             progressPercent = 1 + Math.round(progressPercent * 100) / 100.0;
             if (mode.equals(ApiUtilities.ProgressInfoMode.TEXT)) {
-              logger.info("{}: {} - {} MB", text, progressPercent, OS.getUsedMemory());
+                Runtime rt = Runtime.getRuntime();
+                long usedMemoryMb = (rt.totalMemory() - rt.freeMemory()) / (1024 * 1024);
+                logger.info("{}: {} - {} MB", text, progressPercent, usedMemoryMb);
             }
             else if (mode.equals(ApiUtilities.ProgressInfoMode.DOTS)) {
                 System.out.print(".");

--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/util/OS.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/util/OS.java
@@ -22,6 +22,7 @@ package org.dkpro.jwpl.api.util;
  *
  * @deprecated To be removed without replacement.
  */
+@Deprecated(forRemoval = true)
 public class OS
 {
 


### PR DESCRIPTION
`OS` is deprecated for removal without replacement, yet `CategoryGraph` and `ApiUtilities` still called it, which shows up as a compiler warning on every PR.

- `CategoryGraph`: drop the standalone memory log line.
- `ApiUtilities.printProgressInfo`: compute the used memory with `Runtime` directly.
- `OS`: add `@Deprecated(forRemoval = true)` to match its Javadoc.