### PR TITLE
Release 2.1.0

### DIFF
--- a/dkpro-jwpl-api/pom.xml
+++ b/dkpro-jwpl-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.dkpro.jwpl</groupId>
     <artifactId>dkpro-jwpl</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dkpro-jwpl-api</artifactId>

--- a/dkpro-jwpl-api/pom.xml
+++ b/dkpro-jwpl-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.dkpro.jwpl</groupId>
     <artifactId>dkpro-jwpl</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0</version>
   </parent>
 
   <artifactId>dkpro-jwpl-api</artifactId>

--- a/dkpro-jwpl-build/pom.xml
+++ b/dkpro-jwpl-build/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.dkpro.jwpl</groupId>
     <artifactId>dkpro-jwpl</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0</version>
   </parent>
 
   <artifactId>dkpro-jwpl-build</artifactId>

--- a/dkpro-jwpl-build/pom.xml
+++ b/dkpro-jwpl-build/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.dkpro.jwpl</groupId>
     <artifactId>dkpro-jwpl</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dkpro-jwpl-build</artifactId>

--- a/dkpro-jwpl-datamachine/pom.xml
+++ b/dkpro-jwpl-datamachine/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.jwpl</groupId>
     <artifactId>dkpro-jwpl</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0</version>
   </parent>
   <artifactId>dkpro-jwpl-datamachine</artifactId>
   <name>DataMachine</name>

--- a/dkpro-jwpl-datamachine/pom.xml
+++ b/dkpro-jwpl-datamachine/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.jwpl</groupId>
     <artifactId>dkpro-jwpl</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>dkpro-jwpl-datamachine</artifactId>
   <name>DataMachine</name>

--- a/dkpro-jwpl-mwdumper/pom.xml
+++ b/dkpro-jwpl-mwdumper/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.jwpl</groupId>
     <artifactId>dkpro-jwpl</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>dkpro-jwpl-mwdumper</artifactId>
   <name>MediaWiki Dumper</name>

--- a/dkpro-jwpl-mwdumper/pom.xml
+++ b/dkpro-jwpl-mwdumper/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.jwpl</groupId>
     <artifactId>dkpro-jwpl</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0</version>
   </parent>
   <artifactId>dkpro-jwpl-mwdumper</artifactId>
   <name>MediaWiki Dumper</name>

--- a/dkpro-jwpl-parser/pom.xml
+++ b/dkpro-jwpl-parser/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.dkpro.jwpl</groupId>
     <artifactId>dkpro-jwpl</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0</version>
   </parent>
   <artifactId>dkpro-jwpl-parser</artifactId>
   <name>MediaWiki Parser</name>

--- a/dkpro-jwpl-parser/pom.xml
+++ b/dkpro-jwpl-parser/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.dkpro.jwpl</groupId>
     <artifactId>dkpro-jwpl</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>dkpro-jwpl-parser</artifactId>
   <name>MediaWiki Parser</name>

--- a/dkpro-jwpl-revisionmachine/pom.xml
+++ b/dkpro-jwpl-revisionmachine/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.dkpro.jwpl</groupId>
     <artifactId>dkpro-jwpl</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0</version>
   </parent>
   <artifactId>dkpro-jwpl-revisionmachine</artifactId>
   <name>RevisionMachine</name>

--- a/dkpro-jwpl-revisionmachine/pom.xml
+++ b/dkpro-jwpl-revisionmachine/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.dkpro.jwpl</groupId>
     <artifactId>dkpro-jwpl</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>dkpro-jwpl-revisionmachine</artifactId>
   <name>RevisionMachine</name>

--- a/dkpro-jwpl-timemachine/pom.xml
+++ b/dkpro-jwpl-timemachine/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.jwpl</groupId>
     <artifactId>dkpro-jwpl</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>dkpro-jwpl-timemachine</artifactId>
   <name>TimeMachine</name>

--- a/dkpro-jwpl-timemachine/pom.xml
+++ b/dkpro-jwpl-timemachine/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.jwpl</groupId>
     <artifactId>dkpro-jwpl</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0</version>
   </parent>
   <artifactId>dkpro-jwpl-timemachine</artifactId>
   <name>TimeMachine</name>

--- a/dkpro-jwpl-tutorial/pom.xml
+++ b/dkpro-jwpl-tutorial/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.dkpro.jwpl</groupId>
     <artifactId>dkpro-jwpl</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/dkpro-jwpl-tutorial/pom.xml
+++ b/dkpro-jwpl-tutorial/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.dkpro.jwpl</groupId>
     <artifactId>dkpro-jwpl</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/dkpro-jwpl-util/pom.xml
+++ b/dkpro-jwpl-util/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.jwpl</groupId>
     <artifactId>dkpro-jwpl</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0</version>
   </parent>
   <artifactId>dkpro-jwpl-util</artifactId>
   <name>API Utils</name>

--- a/dkpro-jwpl-util/pom.xml
+++ b/dkpro-jwpl-util/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.jwpl</groupId>
     <artifactId>dkpro-jwpl</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>dkpro-jwpl-util</artifactId>
   <name>API Utils</name>

--- a/dkpro-jwpl-wikimachine/pom.xml
+++ b/dkpro-jwpl-wikimachine/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.jwpl</groupId>
     <artifactId>dkpro-jwpl</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0</version>
   </parent>
   <artifactId>dkpro-jwpl-wikimachine</artifactId>
   <name>WikiMachine</name>

--- a/dkpro-jwpl-wikimachine/pom.xml
+++ b/dkpro-jwpl-wikimachine/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro.jwpl</groupId>
     <artifactId>dkpro-jwpl</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>dkpro-jwpl-wikimachine</artifactId>
   <name>WikiMachine</name>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <description>A free, Java-based application programming interface that allows to access all information contained in Wikipedia.</description>
   <groupId>org.dkpro.jwpl</groupId>
   <artifactId>dkpro-jwpl</artifactId>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>2.1.0</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <description>A free, Java-based application programming interface that allows to access all information contained in Wikipedia.</description>
   <groupId>org.dkpro.jwpl</groupId>
   <artifactId>dkpro-jwpl</artifactId>
-  <version>2.1.0</version>
+  <version>2.2.0-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Release 2.1.0. Tagged as `dkpro-jwpl-2.1.0`; staged on Central Portal as deployment a28fb25b-15fe-4297-9f21-aa0d072a5bfb (validated, awaiting manual publish).