### PR TITLE
Version 2.1.0

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -8,6 +8,12 @@
 #
 # Possible status: "stable", "unstable"
 
+- version: 2.1.0
+  date: 2026-09-10
+  status: stable
+  groupId: org.dkpro.jwpl
+  artifactId: dkpro-jwpl
+
 - version: 2.0.2
   date: 2026-02-03
   status: stable
@@ -26,7 +32,7 @@
   groupId: org.dkpro.jwpl
   artifactId: dkpro-jwpl
 
-- version: 2.0.3-SNAPSHOT
+- version: 2.2.0-SNAPSHOT
   date: unknown
   status: unstable
   groupId: org.dkpro.jwpl


### PR DESCRIPTION
Adds the 2.1.0 release to the website and moves the development snapshot to 2.2.0-SNAPSHOT.