### PR TITLE
#77: Add Page.getVisibleCategories to leave out hidden categories

### DIFF
--- a/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Page.java
+++ b/dkpro-jwpl-api/src/main/java/org/dkpro/jwpl/api/Page.java
@@ -48,6 +48,11 @@ public class Page
     implements WikiConstants
 {
 
+    /**
+     * The title of the category that holds the hidden categories in English Wikipedia.
+     */
+    public static final String HIDDEN_CATEGORIES_TITLE = "Hidden_categories";
+
     private final Wikipedia wiki;
 
     private final PageDAO pageDAO;
@@ -301,6 +306,64 @@ public class Page
             nrOfCategories = returnValue.intValue();
         }
         return nrOfCategories;
+    }
+
+    /**
+     * Returns the categories of this page, leaving out the hidden categories of English Wikipedia,
+     * i.e. the subcategories of {@value #HIDDEN_CATEGORIES_TITLE}. These are maintenance
+     * categories, such as "All articles with dead external links", which Wikipedia does not show on
+     * the page.
+     * <p>
+     * For other language editions, use {@link #getVisibleCategories(String)} with the title of that
+     * edition's hidden-categories category.
+     *
+     * @return The categories of this page that are not hidden. If there is no
+     *         {@value #HIDDEN_CATEGORIES_TITLE} category, all categories of this page.
+     * @throws WikiApiException
+     *             Thrown if errors occurred.
+     */
+    public Set<Category> getVisibleCategories() throws WikiApiException
+    {
+        return getVisibleCategories(HIDDEN_CATEGORIES_TITLE);
+    }
+
+    /**
+     * Returns the categories of this page, leaving out the hidden ones. A category is hidden if it
+     * is a direct subcategory of the category with the given title.
+     *
+     * @param hiddenCategoriesTitle
+     *            The title of the category that holds the hidden categories, e.g.
+     *            {@value #HIDDEN_CATEGORIES_TITLE}. Must not be {@code null} or blank.
+     * @return The categories of this page that are not hidden. If there is no category with the
+     *         given title, all categories of this page.
+     * @throws IllegalArgumentException
+     *             Thrown if {@code hiddenCategoriesTitle} is {@code null} or blank.
+     * @throws WikiApiException
+     *             Thrown if errors occurred.
+     */
+    public Set<Category> getVisibleCategories(String hiddenCategoriesTitle) throws WikiApiException
+    {
+        if (hiddenCategoriesTitle == null || hiddenCategoriesTitle.isBlank()) {
+            throw new IllegalArgumentException(
+                    "The title of the hidden categories category must not be null or blank.");
+        }
+
+        int hiddenCategoriesId;
+        try {
+            hiddenCategoriesId = wiki.getCategory(hiddenCategoriesTitle).getPageId();
+        }
+        catch (WikiPageNotFoundException e) {
+            // Without a hidden categories category, none of the categories of this page is hidden.
+            return getCategories();
+        }
+
+        Set<Category> visibleCategories = new HashSet<>();
+        for (Category category : getCategories()) {
+            if (!category.getParentIDs().contains(hiddenCategoriesId)) {
+                visibleCategories.add(category);
+            }
+        }
+        return visibleCategories;
     }
 
     /**

--- a/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/PageTest.java
+++ b/dkpro-jwpl-api/src/test/java/org/dkpro/jwpl/api/PageTest.java
@@ -20,11 +20,13 @@ package org.dkpro.jwpl.api;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -217,6 +219,45 @@ public class PageTest
             fail("A WikiTitleParsingException occurred while accessing the category title of the page: "
                     + e.getLocalizedMessage());
         }
+    }
+
+    @Test
+    public void testGetVisibleCategoriesWithoutHiddenCategoriesCategory() throws Exception
+    {
+        // The test database has no "Hidden_categories" category, so no category is hidden.
+        assertEquals(Set.of("SIR", "Disambiguation"), titlesOf(page.getVisibleCategories()));
+    }
+
+    @Test
+    public void testGetVisibleCategoriesLeavesOutSubcategoriesOfHiddenCategory() throws Exception
+    {
+        // "SIR" is a subcategory of "Projects_of_UKP", "Disambiguation" of "Telecooperation".
+        assertEquals(Set.of("Disambiguation"),
+                titlesOf(page.getVisibleCategories("Projects_of_UKP")));
+        assertEquals(Set.of("SIR"), titlesOf(page.getVisibleCategories("Telecooperation")));
+    }
+
+    @Test
+    public void testGetVisibleCategoriesWithUnknownHiddenCategory() throws Exception
+    {
+        assertEquals(Set.of("SIR", "Disambiguation"),
+                titlesOf(page.getVisibleCategories("No_such_category")));
+    }
+
+    @Test
+    public void testGetVisibleCategoriesRejectsNullOrBlankTitle()
+    {
+        assertThrows(IllegalArgumentException.class, () -> page.getVisibleCategories(null));
+        assertThrows(IllegalArgumentException.class, () -> page.getVisibleCategories(" "));
+    }
+
+    private static Set<String> titlesOf(Set<Category> categories) throws WikiTitleParsingException
+    {
+        Set<String> titles = new HashSet<>();
+        for (Category category : categories) {
+            titles.add(category.getTitle().getPlainTitle());
+        }
+        return titles;
     }
 
     @Test


### PR DESCRIPTION
Closes #77.

`Page.getCategories()` also returns Wikipedia's hidden maintenance categories, such as "All articles with dead external links". This adds a way to leave them out.

- `getVisibleCategories()` leaves out the subcategories of `Hidden_categories`, the category that holds the hidden categories in English Wikipedia. If the database has no such category, it returns all categories.
- `getVisibleCategories(String)` takes the title of that category, for other language editions.
- A title that doesn't exist also means nothing is hidden. A `null` or blank title throws an `IllegalArgumentException`.
- As suggested in the issue, a category counts as hidden if it is a direct subcategory of that category. The category is now looked up by title instead of a hard-coded page ID.
- The tests use existing categories of the test database as the hidden-categories category, so the test data is unchanged.