### PR TITLE
#80: Recommend a disambiguation category that contains all disambiguation pages

### DIFF
--- a/pages/DataMachine.md
+++ b/pages/DataMachine.md
@@ -20,7 +20,7 @@ permalink: "/DataMachine/"
     * **Attention:** For large dumps you need to increase the amount of memory assigned to the JVM using e.g. the "-Xmx2g" flag to assign 2GB of memory. For the recent English dump you will need at least 4GB. If your system uses a different file encoding you might need to add the `-Dfile.encoding=utf8` flag.
       * LANGUAGE - a language string matching one the [JWPL\_Languages](/dkpro-jwpl/JWPL_Languages).
       * MAIN\_CATEGORY\_NAME - the name of the main (top) category of the Wikipedia category hierarchy
-      * DISAMBIGUATION\_CATEGORY\_NAME - the name of the category that contains the disambiguation categories
+      * DISAMBIGUATION\_CATEGORY\_NAME - the name of the category that directly contains the disambiguation pages (see [Choosing the disambiguation category](#choosing-the-disambiguation-category))
       * SOURCE\_DIRECTORY - the path to the directory containing the source files
   * Patience :) This is going to take a while... While the DataMachine is running, it creates three temporary .bin files. These are only needed during processing time and can be deleted once all files in the output directory have been produced.
   * Eventually, you should get 11 txt files in an "output" subfolder
@@ -35,13 +35,25 @@ permalink: "/DataMachine/"
 ## Example Transformation Commands
 (Note: increase heap space for large Wikipedia versions with the -Xmx flag)
 
-  * `java -Xmx4g -jar JWPLDataMachine.jar english Contents Disambiguation_pages ~/enwiki/20081013`
-  * `java -jar JWPLDataMachine.jar simple_english Contents Disambiguation ./`
+  * `java -Xmx4g -jar JWPLDataMachine.jar english Contents All_article_disambiguation_pages ~/enwiki/20081013`
+  * `java -jar JWPLDataMachine.jar simple_english Contents All_article_disambiguation_pages ./`
   * `java -jar JWPLDataMachine.jar spanish Índice_de_categorías Wikipedia:Desambiguación ~/eswiki/20080416/`
   * `java -Xmx2g -jar JWPLDataMachine.jar german !Hauptkategorie Begriffsklärung ~/dewiki/20080422/`
   * `java -jar JWPLDataMachine.jar dutch Alles Doorverwijspagina ~/nlwiki/200810408`
 
-Mind that the names of the main category or the category marking disambiguation pages may change over time. E.g. the English category for disambiguation pages was called "Disambiguation" for a long time, while now it is "Disambiguation\_pages".
+Mind that the names of the main category or the category marking disambiguation pages may change over time. E.g. the English category for disambiguation pages was called "Disambiguation" for a long time, and later "Disambiguation\_pages".
+
+## Choosing the disambiguation category
+
+The DataMachine marks a page as a disambiguation page only if the page is *directly* in the category passed as DISAMBIGUATION\_CATEGORY\_NAME. Pages that are only in a subcategory of it are not marked.
+
+Many disambiguation pages are only in such a subcategory. In the English Wikipedia, for example, pages using the human name disambiguation template are in "Human name disambiguation pages", a subcategory of "Disambiguation\_pages". As of September 2026, "Disambiguation\_pages" directly contains about 235,000 pages, while the English Wikipedia has about 380,000 disambiguation pages. With "Disambiguation\_pages", about 145,000 of them are therefore not marked (see [#80](https://github.com/dkpro/dkpro-jwpl/issues/80)).
+
+The disambiguation templates also add every disambiguation page to a hidden tracking category, which is not split into subcategories. Use that category instead:
+
+  * English and Simple English Wikipedia: `All_article_disambiguation_pages`, which contains the disambiguation pages in the article namespace. `All_disambiguation_pages` also contains those in other namespaces.
+
+For other language versions, check which category directly contains all disambiguation pages.
 
 ## Discussion Pages
 

--- a/pages/TimeMachine.md
+++ b/pages/TimeMachine.md
@@ -37,7 +37,7 @@ permalink: "/TimeMachine/"
   <comment>This a configuration for the JWPL TimeMachine</comment>
   <entry key="language">english</entry>
   <entry key="mainCategory">Contents</entry>
-  <entry key="disambiguationCategory">Disambiguation_pages</entry>
+  <entry key="disambiguationCategory">All_article_disambiguation_pages</entry>
   <entry key="fromTimestamp">20060101000000</entry>
   <entry key="toTimestamp">20060102000000</entry>
   <entry key="each">1</entry>
@@ -55,7 +55,7 @@ permalink: "/TimeMachine/"
 |:--------------|:----------------|:----------------------|
 | language      | The used language. | The language string must correspond to one of the values enumerated in WikiConstants.Language in the JWPL. Examples: english, german, frensh, arabic. |
 | mainCategory  | The title of the main category of the Wikipedia language version used. | For example, "Contents" for the English Wikipedia or "!Hauptkategorie" for the German Wikipedia. |
-| disambiguationCategory | The title of the disambiguation category of the Wikipedia language version used. | For example, "Disambiguation\_pages" for the English Wikipedia or "Begriffsklärung" for the German Wikipedia. |
+| disambiguationCategory | The title of the category that directly contains the disambiguation pages of the Wikipedia language version used. Pages that are only in a subcategory are not marked as disambiguation pages. | For example, "All\_article\_disambiguation\_pages" for the English Wikipedia or "Begriffsklärung" for the German Wikipedia. See [Choosing the disambiguation category](/dkpro-jwpl/DataMachine/#choosing-the-disambiguation-category). |
 | fromTimestamp | yyyymmddhhmmss  | The timestamp of the first version to be extracted. |
 | toTimestamp   | yyyymmddhhmmss  | The timestamp of the last version to be extracted. |
 | each          | The number of days to be used as regular interval for extracting versions.|                       |


### PR DESCRIPTION
Fixes #80.

The DataMachine and TimeMachine mark a page as a disambiguation page only if it is *directly* in the configured disambiguation category. Our docs recommend `Disambiguation_pages` for English Wikipedia, but many disambiguation pages are only in one of its subcategories, e.g. the page from the issue, "Alex Dyer", is only in "Human name disambiguation pages". As of today, `Disambiguation_pages` directly contains about 235,000 pages, while English Wikipedia has about 380,000 disambiguation pages, so about 145,000 are not marked.

The disambiguation templates also put every disambiguation page into a hidden tracking category without subcategories. Using that category fixes the issue without any code change.

- The English and Simple English examples in the DataMachine page and the example TimeMachine configuration now use `All_article_disambiguation_pages`. On Simple English Wikipedia, the previous example category `Disambiguation` holds only 2 pages.
- A new "Choosing the disambiguation category" section explains why pages in subcategories are not marked and which category to use.
- The parameter descriptions now say that the category must directly contain the disambiguation pages.
- The Spanish, German and Dutch examples are unchanged, as I did not check those editions. The new section asks users of other language versions to check which category directly contains all disambiguation pages.