### PR TITLE
#69: Record the namespace of each revision

### DIFF
--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/api/Revision.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/api/Revision.java
@@ -102,6 +102,11 @@ public class Revision
     private boolean contributorIsRegistered;
 
     /**
+     * Namespace of the page this revision belongs to, {@code null} if unknown
+     */
+    private Integer namespace;
+
+    /**
      * Reference to RevisionApi
      */
     private transient RevisionApi revisionApi;
@@ -463,6 +468,30 @@ public class Revision
     public Integer getContributorId()
     {
         return contributorId;
+    }
+
+    /**
+     * Returns the namespace of the page this revision belongs to, e.g. 0 for articles and 1 for
+     * their talk pages.
+     *
+     * @return the namespace, or {@code null} if it is unknown. This is always the case for
+     *         databases created by RevisionMachine versions before 2.2.0, which did not record the
+     *         namespace.
+     */
+    public Integer getNamespace()
+    {
+        return namespace;
+    }
+
+    /**
+     * Sets the namespace of the page this revision belongs to.
+     *
+     * @param namespace
+     *            the namespace, {@code null} if unknown
+     */
+    public void setNamespace(Integer namespace)
+    {
+        this.namespace = namespace;
     }
 
     private void writeObject(ObjectOutputStream out) throws IOException

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/api/RevisionApi.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/api/RevisionApi.java
@@ -51,6 +51,11 @@ public class RevisionApi
 {
 
     /**
+     * Whether the revisions table has a Namespace column, {@code null} until it has been checked
+     */
+    private Boolean hasNamespaceColumn;
+
+    /**
      * Creates a new {@link RevisionApi} object with an existing database connection.
      *
      * @param config
@@ -1595,8 +1600,10 @@ public class RevisionApi
     private Revision buildRevisionMetaData(final int fullRevPK, final int limit) throws SQLException
     {
 
-        final String query = "SELECT Revision, PrimaryKey, RevisionCounter, RevisionID, ArticleID, Timestamp, Comment, Minor, ContributorName, ContributorId, ContributorIsRegistered "
-                + "FROM revisions " + "WHERE PrimaryKey >= ? LIMIT " + limit;
+        final boolean namespaceColumn = hasNamespaceColumn();
+        final String query = "SELECT Revision, PrimaryKey, RevisionCounter, RevisionID, ArticleID, Timestamp, Comment, Minor, ContributorName, ContributorId, ContributorIsRegistered"
+                + (namespaceColumn ? ", Namespace" : "") + " FROM revisions "
+                + "WHERE PrimaryKey >= ? LIMIT " + limit;
         /*
          * As HSQL does not support ResultSet.last() per default, we have to specify these extra
          * parameters here.
@@ -1631,11 +1638,32 @@ public class RevisionApi
                 revision.setContributorId(contributorId);
 
                 revision.setContributorIsRegistered(result.getBoolean(11));
+
+                if (namespaceColumn) {
+                    revision.setNamespace(RevisionsTable.getNamespace(result, 12));
+                }
             }
             return revision;
 
         }
 
+    }
+
+    /**
+     * Checks whether the revisions table has a Namespace column. The result is cached, as the
+     * schema does not change while this API is in use.
+     *
+     * @return {@code true} if the column exists, {@code false} for databases created by
+     *         RevisionMachine versions before 2.2.0
+     * @throws SQLException
+     *             if an error occurs while querying the database
+     */
+    private boolean hasNamespaceColumn() throws SQLException
+    {
+        if (hasNamespaceColumn == null) {
+            hasNamespaceColumn = RevisionsTable.hasNamespaceColumn(connection);
+        }
+        return hasNamespaceColumn;
     }
 
     /**

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/api/RevisionIterator.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/api/RevisionIterator.java
@@ -103,6 +103,11 @@ public class RevisionIterator
      */
     private RevisionApi revApi = null;
 
+    /**
+     * Whether the revisions table has a Namespace column, {@code null} until the first query
+     */
+    private Boolean hasNamespaceColumn;
+
     public boolean shouldLoadRevisionText()
     {
         return shouldLoadRevisionText;
@@ -266,9 +271,13 @@ public class RevisionIterator
      */
     private boolean query() throws SQLException
     {
+        if (hasNamespaceColumn == null) {
+            hasNamespaceColumn = RevisionsTable.hasNamespaceColumn(connection);
+        }
+
         String query = "SELECT PrimaryKey, Revision, RevisionCounter,"
-                + " RevisionID, ArticleID, Timestamp, FullRevisionID, ContributorName, ContributorId, Comment, Minor, ContributorIsRegistered "
-                + "FROM revisions";
+                + " RevisionID, ArticleID, Timestamp, FullRevisionID, ContributorName, ContributorId, Comment, Minor, ContributorIsRegistered"
+                + (hasNamespaceColumn ? ", Namespace" : "") + " FROM revisions";
 
         if (primaryKey > 0) {
             query += " WHERE PrimaryKey > " + primaryKey;
@@ -396,6 +405,10 @@ public class RevisionIterator
             revision.setComment(result.getString(10));
             revision.setMinor(result.getBoolean(11));
             revision.setContributorIsRegistered(result.getBoolean(12));
+
+            if (Boolean.TRUE.equals(hasNamespaceColumn)) {
+                revision.setNamespace(RevisionsTable.getNamespace(result, 13));
+            }
 
             return revision;
 

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/api/RevisionsTable.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/api/RevisionsTable.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.jwpl.revisionmachine.api;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * Handles the columns of the {@code revisions} table that not every RevisionMachine database has.
+ */
+final class RevisionsTable
+{
+
+    /**
+     * Name of the column that holds the namespace of the page a revision belongs to. Databases
+     * created by RevisionMachine versions before 2.2.0 do not have it.
+     */
+    static final String NAMESPACE_COLUMN = "Namespace";
+
+    private RevisionsTable()
+    {
+    }
+
+    /**
+     * Checks whether the {@code revisions} table has a {@value #NAMESPACE_COLUMN} column.
+     *
+     * @param connection
+     *            the connection to the RevisionMachine database
+     * @return {@code true} if the column exists, {@code false} otherwise
+     * @throws SQLException
+     *             if an error occurs while querying the database
+     */
+    static boolean hasNamespaceColumn(final Connection connection) throws SQLException
+    {
+        try (Statement statement = connection.createStatement();
+                ResultSet result = statement.executeQuery("SELECT * FROM revisions WHERE 1 = 0")) {
+            ResultSetMetaData metaData = result.getMetaData();
+            for (int i = 1; i <= metaData.getColumnCount(); i++) {
+                if (NAMESPACE_COLUMN.equalsIgnoreCase(metaData.getColumnName(i))) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Reads the namespace from the given column of the current row.
+     *
+     * @param result
+     *            the result set, positioned on a row
+     * @param columnIndex
+     *            the index of the {@value #NAMESPACE_COLUMN} column in the result set
+     * @return the namespace, or {@code null} if it was not recorded for this revision
+     * @throws SQLException
+     *             if the column cannot be read
+     */
+    static Integer getNamespace(final ResultSet result, final int columnIndex) throws SQLException
+    {
+        int namespace = result.getInt(columnIndex);
+        return result.wasNull() ? null : namespace;
+    }
+}

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/common/util/WikipediaXMLKeys.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/common/util/WikipediaXMLKeys.java
@@ -124,6 +124,16 @@ public enum WikipediaXMLKeys
     KEY_END_NAMESPACES("</namespaces>"),
 
     /**
+     * Indicates the start of the namespace of a page
+     */
+    KEY_START_NS("<ns>"),
+
+    /**
+     * Indicates the end of the namespace of a page
+     */
+    KEY_END_NS("</ns>"),
+
+    /**
      * Indicates the start of a text segment
      */
     KEY_START_TEXT("<text xml:space=\"preserve\">"),

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/article/reader/WikipediaXMLReader.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/article/reader/WikipediaXMLReader.java
@@ -86,6 +86,12 @@ public class WikipediaXMLReader
     private ArticleFilter articleFilter;
 
     /**
+     * Mapping of namespace ids to the corresponding article title prefixes, read from the
+     * {@code <siteinfo>} of the dump
+     */
+    private Map<Integer, String> namespaceMap = new HashMap<>();
+
+    /**
      * Creates a new WikipediaXMLReader.
      *
      * @throws ConfigurationException
@@ -172,6 +178,8 @@ public class WikipediaXMLReader
         keys.addKeyword(WikipediaXMLKeys.KEY_END_CONTRIBUTOR.getKeyword(), WikipediaXMLKeys.KEY_END_CONTRIBUTOR);
         keys.addKeyword(WikipediaXMLKeys.KEY_START_NAMESPACES.getKeyword(), WikipediaXMLKeys.KEY_START_NAMESPACES);
         keys.addKeyword(WikipediaXMLKeys.KEY_END_NAMESPACES.getKeyword(), WikipediaXMLKeys.KEY_END_NAMESPACES);
+        keys.addKeyword(WikipediaXMLKeys.KEY_START_NS.getKeyword(), WikipediaXMLKeys.KEY_START_NS);
+        keys.addKeyword(WikipediaXMLKeys.KEY_END_NS.getKeyword(), WikipediaXMLKeys.KEY_END_NS);
     }
 
     /**
@@ -180,7 +188,7 @@ public class WikipediaXMLReader
      */
     private void initNamespaces()
     {
-        Map<Integer, String> namespaceMap = new HashMap<>();
+        namespaceMap = new HashMap<>();
         try {
             int b = read();
 
@@ -221,7 +229,9 @@ public class WikipediaXMLReader
                             }
                         }
 
-                        articleFilter.initializeNamespaces(namespaceMap);
+                        if (articleFilter != null) {
+                            articleFilter.initializeNamespaces(namespaceMap);
+                        }
                         return; // init done
 
                     }
@@ -344,6 +354,7 @@ public class WikipediaXMLReader
 
                 case KEY_START_TITLE:
                 case KEY_START_ID:
+                case KEY_START_NS:
                     buffer = new StringBuilder();
                     break;
 
@@ -370,7 +381,20 @@ public class WikipediaXMLReader
                     buffer = null;
                     break;
 
+                case KEY_END_NS:
+                    size = buffer.length();
+                    buffer.delete(size - WikipediaXMLKeys.KEY_END_NS.getKeyword().length(), size);
+
+                    this.taskHeader.setNamespace(Integer.parseInt(buffer.toString().trim()));
+                    buffer = null;
+                    break;
+
                 case KEY_START_REVISION:
+                    // Dumps without the <ns> element only reveal the namespace of a page
+                    // through the prefix of its title.
+                    if (this.taskHeader.getNamespace() == null) {
+                        this.taskHeader.setNamespace(namespaceOf(this.taskHeader.getArticleName()));
+                    }
                     this.keys.reset();
                     return true;
 
@@ -387,6 +411,27 @@ public class WikipediaXMLReader
 
         throw ErrorFactory.createArticleReaderException(
                 ErrorKeys.DELTA_CONSUMERS_TASK_READER_WIKIPEDIAXMLREADER_UNEXPECTED_END_OF_FILE);
+    }
+
+    /**
+     * Derives the namespace of a page from the prefix of its title, e.g. 1 for "Talk:Main Page".
+     *
+     * @param title
+     *            the page title
+     * @return the namespace, 0 if the title has no namespace prefix, or {@code null} if the
+     *         namespaces of the dump are unknown
+     */
+    private Integer namespaceOf(final String title)
+    {
+        if (namespaceMap.isEmpty() || title == null) {
+            return null;
+        }
+        for (Map.Entry<Integer, String> namespace : namespaceMap.entrySet()) {
+            if (title.startsWith(namespace.getValue() + ":")) {
+                return namespace.getKey();
+            }
+        }
+        return 0;
     }
 
     /**

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/dump/codec/DataFileEncoder.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/dump/codec/DataFileEncoder.java
@@ -89,6 +89,7 @@ public class DataFileEncoder
         }
 
         int articleId = task.getHeader().getArticleId();
+        Integer namespace = task.getHeader().getNamespace();
         Diff diff;
 
         ArrayList<String> list = new ArrayList<>();
@@ -127,7 +128,8 @@ public class DataFileEncoder
                     + diff.getRevisionID() + "," + articleId + "," + diff.getTimeStamp().getTime()
                     + ",\"" + encodeDiff(task, diff) + "\"," + comment + ","
                     + (diff.isMinor() ? "1" : "0") + "," + contributorName + "," + contributorId
-                    + "," + (diff.getContributorIsRegistered() ? "1" : "0");
+                    + "," + (diff.getContributorIsRegistered() ? "1" : "0") + ","
+                    + (namespace == null ? "\\N" : namespace.toString());
 
             // add item to the list
             list.add(tempData);

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/dump/codec/SQLEncoder.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/dump/codec/SQLEncoder.java
@@ -158,7 +158,8 @@ public class SQLEncoder
                 + "Timestamp BIGINT NOT NULL, " + "Revision MEDIUMTEXT NOT NULL, "
                 + "Comment MEDIUMTEXT, " + "Minor TINYINT NOT NULL, "
                 + "ContributorName TEXT NOT NULL, " + "ContributorId INTEGER UNSIGNED, "
-                + "ContributorIsRegistered TINYINT NOT NULL, " + "PRIMARY KEY(PrimaryKey)"
+                + "ContributorIsRegistered TINYINT NOT NULL, " + "Namespace INTEGER, "
+                + "PRIMARY KEY(PrimaryKey)"
                 + ") TYPE = MyISAM DEFAULT CHARSET utf8 COLLATE utf8_general_ci;";
 
         binaryTableRevision = "CREATE TABLE IF NOT EXISTS revisions ("
@@ -169,7 +170,8 @@ public class SQLEncoder
                 + "Timestamp BIGINT NOT NULL, " + "Revision MEDIUMBLOB NOT NULL,"
                 + "Comment MEDIUMTEXT, " + "Minor TINYINT NOT NULL, "
                 + "ContributorName TEXT NOT NULL, " + "ContributorId INTEGER UNSIGNED, "
-                + "ContributorIsRegistered TINYINT NOT NULL, " + "PRIMARY KEY(PrimaryKey)"
+                + "ContributorIsRegistered TINYINT NOT NULL, " + "Namespace INTEGER, "
+                + "PRIMARY KEY(PrimaryKey)"
                 + ") TYPE = MyISAM DEFAULT CHARSET utf8 COLLATE utf8_general_ci;";
 
     }
@@ -206,6 +208,7 @@ public class SQLEncoder
         }
 
         int articleId = task.getHeader().getArticleId();
+        Integer namespace = task.getHeader().getNamespace();
         Diff diff;
 
         ArrayList<SQLEncoding> list = new ArrayList<>();
@@ -241,7 +244,8 @@ public class SQLEncoder
             tempData = "(null, " + this.lastFullRevID + "," + diff.getRevisionCounter() + ","
                     + diff.getRevisionID() + "," + articleId + "," + diff.getTimeStamp().getTime()
                     + ",?," + comment + "," + (diff.isMinor() ? "1" : "0") + "," + contributorId
-                    + "," + (diff.getContributorIsRegistered() ? "1" : "0") + ")";
+                    + "," + (diff.getContributorIsRegistered() ? "1" : "0") + ","
+                    + namespace + ")";
             tempBinaryData = binaryDiff(task, diff);
 
             // if the limit would be reached start a new encoding
@@ -325,6 +329,7 @@ public class SQLEncoder
         }
 
         int articleId = task.getHeader().getArticleId();
+        Integer namespace = task.getHeader().getNamespace();
         Diff diff;
 
         ArrayList<SQLEncoding> list = new ArrayList<>();
@@ -359,7 +364,8 @@ public class SQLEncoder
                     + diff.getRevisionID() + "," + articleId + "," + diff.getTimeStamp().getTime()
                     + ",'" + encodeDiff(task, diff) + "'," + comment + ","
                     + (diff.isMinor() ? "1" : "0") + ",'" + diff.getContributorName() + "',"
-                    + contributorId + "," + (diff.getContributorIsRegistered() ? "1" : "0") + ")";
+                    + contributorId + "," + (diff.getContributorIsRegistered() ? "1" : "0") + ","
+                    + namespace + ")";
 
             // if the limit would be reached start a new encoding
             if ((revisionEncoding.byteSize() + tempData.length() >= LIMIT_SQL_STATEMENT_SIZE)

--- a/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/data/tasks/info/ArticleInformation.java
+++ b/dkpro-jwpl-revisionmachine/src/main/java/org/dkpro/jwpl/revisionmachine/difftool/data/tasks/info/ArticleInformation.java
@@ -72,6 +72,11 @@ public class ArticleInformation
     private int ignoredRevisionsCounter;
 
     /**
+     * Namespace of the article, {@code null} if unknown
+     */
+    private Integer namespace;
+
+    /**
      * Original size of the article
      */
     private long originalSize;
@@ -211,6 +216,16 @@ public class ArticleInformation
     public int getIgnoredRevisionsCounter()
     {
         return ignoredRevisionsCounter;
+    }
+
+    /**
+     * Returns the namespace of the article.
+     *
+     * @return namespace, {@code null} if unknown
+     */
+    public Integer getNamespace()
+    {
+        return namespace;
     }
 
     /**
@@ -373,6 +388,17 @@ public class ArticleInformation
     }
 
     /**
+     * Sets the namespace of the article.
+     *
+     * @param namespace
+     *            namespace, {@code null} if unknown
+     */
+    public void setNamespace(final Integer namespace)
+    {
+        this.namespace = namespace;
+    }
+
+    /**
      * Sets the original size of the article.
      *
      * @param originalSize
@@ -453,6 +479,8 @@ public class ArticleInformation
         b.append(articleId);
         b.append("\r\n\tARTICLENAME:       \t");
         b.append(articleName);
+        b.append("\r\n\tNAMESPACE:         \t");
+        b.append(namespace);
         b.append("\r\n\r\n\tNUMBER REVISIONS:\t[");
         b.append(this.revisionCounter);
         b.append(" + ");

--- a/dkpro-jwpl-revisionmachine/src/test-e2e/java/org/dkpro/jwpl/revisionmachine/difftool/DiffToolE2ETest.java
+++ b/dkpro-jwpl-revisionmachine/src/test-e2e/java/org/dkpro/jwpl/revisionmachine/difftool/DiffToolE2ETest.java
@@ -18,6 +18,7 @@
 package org.dkpro.jwpl.revisionmachine.difftool;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -86,11 +87,14 @@ public class DiffToolE2ETest {
   }
 
   @Test
-  void testExecJWPLDiffTool() {
+  void testExecJWPLDiffTool() throws IOException {
     // Add in required arguments
     cmd.add(CONF_FILE);
     int exitCode = execTool(cmd);
     assertEquals(0,  exitCode);
+    // The revisions table records the namespace of each revision
+    String sql = Files.readString(Path.of(OUTPUT_DIR, "output_1.sql"));
+    assertTrue(sql.contains("Namespace INTEGER"), sql);
   }
 
   @Test

--- a/dkpro-jwpl-revisionmachine/src/test/java/org/dkpro/jwpl/revisionmachine/RevisionNamespaceTest.java
+++ b/dkpro-jwpl-revisionmachine/src/test/java/org/dkpro/jwpl/revisionmachine/RevisionNamespaceTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.jwpl.revisionmachine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+
+import org.dkpro.jwpl.api.DatabaseConfiguration;
+import org.dkpro.jwpl.api.WikiConstants.Language;
+import org.dkpro.jwpl.revisionmachine.api.Revision;
+import org.dkpro.jwpl.revisionmachine.api.RevisionAPIConfiguration;
+import org.dkpro.jwpl.revisionmachine.api.RevisionApi;
+import org.dkpro.jwpl.revisionmachine.api.RevisionIterator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Reads the namespace of revisions from databases with and without the Namespace column. The test
+ * data set was created before the column existed, a copy of it gets the column added.
+ */
+public class RevisionNamespaceTest
+    extends BaseJWPLTest
+{
+
+    private static final String DATABASE = "wikiapi_simple_20090119_stripped";
+
+    // A revision of the page 'Car', the only page in the stripped test data set
+    private static final int REVISION_ID = 1142935;
+
+    @TempDir
+    static Path tempDir;
+
+    private static DatabaseConfiguration legacyDb;
+
+    private static DatabaseConfiguration namespaceDb;
+
+    @BeforeAll
+    public static void setUpDatabases() throws Exception
+    {
+        legacyDb = obtainHSDLDBConfiguration(DATABASE, Language.simple_english);
+
+        Files.copy(Path.of("src/test/resources/db", DATABASE + ".script"),
+                tempDir.resolve(DATABASE + ".script"));
+        String url = "jdbc:hsqldb:file:" + tempDir.resolve(DATABASE) + ";shutdown=true";
+        try (Connection connection = DriverManager.getConnection(url, "sa", "");
+                Statement statement = connection.createStatement()) {
+            statement.execute("ALTER TABLE revisions ADD COLUMN Namespace INTEGER");
+            statement.execute("UPDATE revisions SET Namespace = 0");
+        }
+        namespaceDb = new DatabaseConfiguration("org.hsqldb.jdbcDriver", url, "localhost",
+                DATABASE, "sa", "", Language.simple_english);
+    }
+
+    @Test
+    public void testRevisionApiReadsNamespace() throws Exception
+    {
+        RevisionApi revisionApi = new RevisionApi(namespaceDb);
+        try {
+            assertEquals(Integer.valueOf(0), revisionApi.getRevision(REVISION_ID).getNamespace());
+        }
+        finally {
+            revisionApi.close();
+        }
+    }
+
+    @Test
+    public void testRevisionApiWithoutNamespaceColumn() throws Exception
+    {
+        RevisionApi revisionApi = new RevisionApi(legacyDb);
+        try {
+            Revision revision = revisionApi.getRevision(REVISION_ID);
+            assertEquals(REVISION_ID, revision.getRevisionID());
+            assertNull(revision.getNamespace());
+        }
+        finally {
+            revisionApi.close();
+        }
+    }
+
+    @Test
+    public void testRevisionIteratorReadsNamespace() throws Exception
+    {
+        RevisionIterator revisionIterator = new RevisionIterator(
+                new RevisionAPIConfiguration(namespaceDb));
+        try {
+            assertTrue(revisionIterator.hasNext());
+            assertEquals(Integer.valueOf(0), revisionIterator.next().getNamespace());
+        }
+        finally {
+            revisionIterator.close();
+        }
+    }
+
+    @Test
+    public void testRevisionIteratorWithoutNamespaceColumn() throws Exception
+    {
+        RevisionIterator revisionIterator = new RevisionIterator(
+                new RevisionAPIConfiguration(legacyDb));
+        try {
+            assertTrue(revisionIterator.hasNext());
+            assertNull(revisionIterator.next().getNamespace());
+        }
+        finally {
+            revisionIterator.close();
+        }
+    }
+}

--- a/dkpro-jwpl-revisionmachine/src/test/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/article/reader/WikipediaXMLReaderTest.java
+++ b/dkpro-jwpl-revisionmachine/src/test/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/article/reader/WikipediaXMLReaderTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.jwpl.revisionmachine.difftool.consumer.article.reader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.dkpro.jwpl.revisionmachine.api.Revision;
+import org.dkpro.jwpl.revisionmachine.difftool.config.ConfigurationManager;
+import org.dkpro.jwpl.revisionmachine.difftool.config.gui.control.ConfigSettings;
+import org.dkpro.jwpl.revisionmachine.difftool.data.tasks.Task;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class WikipediaXMLReaderTest
+{
+
+    private static final String SITEINFO = "<mediawiki><siteinfo><namespaces>"
+            + "<namespace key=\"0\" case=\"first-letter\" />"
+            + "<namespace key=\"1\" case=\"first-letter\">Talk</namespace>"
+            + "<namespace key=\"4\" case=\"first-letter\">Wikipedia</namespace>"
+            + "</namespaces></siteinfo>";
+
+    @BeforeAll
+    public static void setUpConfiguration()
+    {
+        ConfigSettings settings = new ConfigSettings();
+        settings.defaultConfiguration();
+        new ConfigurationManager(settings);
+    }
+
+    @Test
+    public void testReadsNamespaceFromNsElement() throws Exception
+    {
+        String xml = SITEINFO + page("Main Page", "0", 1) + page("Talk:Main Page", "1", 2)
+                + page("Wikipedia:About", "4", 3) + "</mediawiki>";
+
+        assertEquals(List.of(0, 1, 4), readNamespaces(xml));
+    }
+
+    @Test
+    public void testDerivesNamespaceFromTitlePrefixWithoutNsElement() throws Exception
+    {
+        // Older dumps have no <ns> element, so the prefix of the title has to do.
+        String xml = SITEINFO + page("Main Page", null, 1) + page("Talk:Main Page", null, 2)
+                + page("Wikipedia:About", null, 3) + "</mediawiki>";
+
+        assertEquals(List.of(0, 1, 4), readNamespaces(xml));
+    }
+
+    /**
+     * Creates a page with a single revision, laid out like in the dumps: the reader relies on the
+     * whitespace between the elements.
+     */
+    private static String page(String title, String namespace, int id)
+    {
+        return "\n  <page>\n    <title>" + title + "</title>\n"
+                + (namespace == null ? "" : "    <ns>" + namespace + "</ns>\n")
+                + "    <id>" + id + "</id>\n"
+                + "    <revision>\n      <id>" + (id * 10) + "</id>\n"
+                + "      <timestamp>2009-03-16T01:13:23Z</timestamp>\n"
+                + "      <contributor>\n        <username>Someone</username>\n"
+                + "        <id>177</id>\n      </contributor>\n"
+                + "      <text xml:space=\"preserve\">Some text</text>\n"
+                + "    </revision>\n  </page>";
+    }
+
+    private static List<Integer> readNamespaces(String xml) throws Exception
+    {
+        WikipediaXMLReader reader = new WikipediaXMLReader(new StringReader(xml));
+        List<Integer> namespaces = new ArrayList<>();
+        while (reader.hasNext()) {
+            Task<Revision> task = reader.next();
+            namespaces.add(task.getHeader().getNamespace());
+        }
+        return namespaces;
+    }
+}

--- a/dkpro-jwpl-revisionmachine/src/test/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/dump/codec/SQLEncoderTest.java
+++ b/dkpro-jwpl-revisionmachine/src/test/java/org/dkpro/jwpl/revisionmachine/difftool/consumer/dump/codec/SQLEncoderTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.jwpl.revisionmachine.difftool.consumer.dump.codec;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.Timestamp;
+
+import org.dkpro.jwpl.revisionmachine.difftool.config.ConfigurationManager;
+import org.dkpro.jwpl.revisionmachine.difftool.config.gui.control.ConfigSettings;
+import org.dkpro.jwpl.revisionmachine.difftool.data.codec.RevisionCodecData;
+import org.dkpro.jwpl.revisionmachine.difftool.data.tasks.Task;
+import org.dkpro.jwpl.revisionmachine.difftool.data.tasks.content.Diff;
+import org.dkpro.jwpl.revisionmachine.difftool.data.tasks.content.DiffAction;
+import org.dkpro.jwpl.revisionmachine.difftool.data.tasks.content.DiffPart;
+import org.dkpro.jwpl.revisionmachine.difftool.data.tasks.info.ArticleInformation;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class SQLEncoderTest
+{
+
+    @BeforeAll
+    public static void setUpConfiguration()
+    {
+        ConfigSettings settings = new ConfigSettings();
+        settings.defaultConfiguration();
+        new ConfigurationManager(settings);
+    }
+
+    @Test
+    public void testTablesHaveNamespaceColumn() throws Exception
+    {
+        SQLEncoder encoder = new SQLEncoder(null);
+
+        assertTrue(encoder.getTable()[0].contains("Namespace INTEGER"));
+        assertTrue(encoder.getBinaryTable()[0].contains("Namespace INTEGER"));
+    }
+
+    @Test
+    public void testEncodeTaskWritesNamespace() throws Exception
+    {
+        // ... ContributorId, ContributorIsRegistered, Namespace)
+        String sql = new SQLEncoder(null).encodeTask(task(1))[0].getQuery();
+        assertTrue(sql.endsWith(",null,1,1);"), sql);
+    }
+
+    @Test
+    public void testEncodeTaskWritesNullForUnknownNamespace() throws Exception
+    {
+        String sql = new SQLEncoder(null).encodeTask(task(null))[0].getQuery();
+        assertTrue(sql.endsWith(",null,1,null);"), sql);
+    }
+
+    @Test
+    public void testBinaryTaskWritesNamespace() throws Exception
+    {
+        String sql = new SQLEncoder(null).binaryTask(task(1))[0].getQuery();
+        assertTrue(sql.endsWith(",null,1,1);"), sql);
+    }
+
+    @Test
+    public void testDataFileEncoderWritesNamespace() throws Exception
+    {
+        String row = new DataFileEncoder().encodeTask(task(1)).get(0);
+        assertTrue(row.endsWith(",\\N,1,1"), row);
+    }
+
+    @Test
+    public void testDataFileEncoderWritesNullForUnknownNamespace() throws Exception
+    {
+        String row = new DataFileEncoder().encodeTask(task(null)).get(0);
+        assertTrue(row.endsWith(",\\N,1,\\N"), row);
+    }
+
+    /**
+     * Creates a task holding a single full revision of an article in the given namespace.
+     */
+    private static Task<Diff> task(Integer namespace) throws Exception
+    {
+        ArticleInformation header = new ArticleInformation();
+        header.setArticleId(42);
+        header.setArticleName("Talk:Main_Page");
+        header.setNamespace(namespace);
+
+        String text = "Some text";
+        DiffPart part = new DiffPart(DiffAction.FULL_REVISION_UNCOMPRESSED);
+        part.setText(text);
+
+        RevisionCodecData codecData = new RevisionCodecData();
+        codecData.checkBlocksizeL(text.getBytes(StandardCharsets.UTF_8).length);
+
+        Diff diff = new Diff();
+        diff.setRevisionCoutner(1);
+        diff.setRevisionID(7);
+        diff.setTimeStamp(new Timestamp(0));
+        diff.setContributorName("Someone");
+        diff.setContributorIsRegistered(true);
+        diff.add(part);
+        diff.setCodecData(codecData);
+
+        Task<Diff> task = new Task<>(header, 1);
+        task.add(diff);
+        return task;
+    }
+}


### PR DESCRIPTION
Closes #69.

- The DiffTool reads the namespace of each page from its `<ns>` element. For dumps without it, the namespace is derived from the title prefix, using the namespaces in the dump's `<siteinfo>`.
- The `revisions` table gets a nullable `Namespace INTEGER` column at the end. The SQL output and the data file (CSV) output write it for every revision.
- `Revision.getNamespace()` exposes it, and `RevisionApi` and `RevisionIterator` read it. `ChronoIterator` still doesn't set it, like the other metadata it leaves out.
- Existing databases keep working: `RevisionApi` and `RevisionIterator` check once whether the column exists, and `getNamespace()` returns `null` if it doesn't. New DiffTool output needs a new table, as its rows have one more value than old tables have columns.
- The "Discussion" prefix mentioned in the issue no longer exists in the code, so there was nothing to replace.
- Also fixes a `NullPointerException` when a `WikipediaXMLReader` is created without an article filter.

Known and not changed here: on dumps in the current export format (0.11), the reader fails on every `<text bytes="…" xml:space="preserve">` element, so the DiffTool writes no revisions for those pages. This already happens on master: the e2e run writes 0 rows before and after this change. It needs a separate fix.