### PR TITLE
Update Sweble to 4.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <fastutil.version>8.5.19</fastutil.version>
     <fau.ptk.version>3.0.8</fau.ptk.version>
     <fau.utils.version>3.0.8</fau.utils.version>
-    <org.sweble.wikitext.version>4.0.1</org.sweble.wikitext.version>
+    <org.sweble.wikitext.version>4.1.0</org.sweble.wikitext.version>
 
     <commons.codec.version>1.22.1</commons.codec.version>
     <commons.compress.version>1.28.0</commons.compress.version>


### PR DESCRIPTION
Updates Sweble from 4.0.1 to 4.1.0 ([release notes](https://github.com/rzo1/sweble-wikitext/releases/tag/v4.1.0)).

**Note:** 4.1.0 was released just now. It takes some time until it is synced to Maven Central, so the build of this PR can't resolve it yet. Stay tuned, I'll re-run the checks once it is available.

What changes for JWPL:
- No code changes are needed. JWPL only uses Sweble APIs that stayed compatible (`WikiConfig`, `DefaultConfigEnWp`, `WtEngineImpl`, `EngProcessedPage`, `PageTitle`, the AST nodes).
- Parsing follows MediaWiki more closely, for example paragraphs after framed images, indented tables in definition lists and unclosed extension tags that stay text. The engine now limits template depth, expansion size and nesting depth, and XML parsing is hardened against XXE.
- The unit data of `{{convert}}` moved into the separate artifact `swc-convert-data`, which is licensed under CC BY-SA 4.0. JWPL doesn't need it: `PlainTextConverter` leaves template output out. The plain text of a page with `{{convert}}` is the same with 4.0.1, with 4.1.0, and with 4.1.0 plus `swc-convert-data`.

### Testing
`mvn clean verify -Ptest-e2e-tools -Prat-check -Pdb-hsqldb` on JDK 21, with Sweble 4.1.0 from the local repository: 1035 tests, 0 failures, 1 skipped. The only skipped test is `RevisionApiTest.lastRevisionTest`, as on `master`. The build with 4.0.1 gives the same result.
